### PR TITLE
Docker setup to enable running locally on Apple Silicon

### DIFF
--- a/Dockerfile.m1
+++ b/Dockerfile.m1
@@ -1,0 +1,12 @@
+FROM golang:1.16-stretch as build
+
+WORKDIR /service
+ADD . /service
+
+# RUN cd /service && go build -o /http-service .
+
+CMD make debug
+
+# TEST
+FROM build as test
+

--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,6 @@ test-component:
 docker_test:
 	docker build -f Dockerfile.m1 . -t template_test --target=test
 	docker-compose -f docker-compose-m1.yml up -d
+	docker-compose -f docker-compose-m1.yml exec -T http go test ./...
 	docker-compose -f docker-compose-m1.yml exec -T http go test -component
 	docker-compose -f docker-compose-m1.yml down

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,10 @@ convey:
 .PHONY: test-component
 test-component:
 	go test -cover -coverpkg=github.com/ONSdigital/dp-files-api/... -component
+
+.PHONY: docker_test
+docker_test:
+	docker build -f Dockerfile.m1 . -t template_test --target=test
+	docker-compose -f docker-compose-m1.yml up -d
+	docker-compose -f docker-compose-m1.yml exec -T http go test -component
+	docker-compose -f docker-compose-m1.yml down

--- a/docker-compose-m1.yml
+++ b/docker-compose-m1.yml
@@ -1,0 +1,7 @@
+version: "3"
+
+services:
+  http:
+    image: template_test
+    ports:
+      - "8080:8080"


### PR DESCRIPTION


### What

Creating docker setup to enable running of component test on an M1 Mac as dp-mongodb-in-memory does not work on apple silicon

### How to review

make docker_test

### Who can review

anyone
