### PR TITLE
Create new endpoint for marking file upload as complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vendor/
 .idea/
 *.iml
 *.iws
+*.out

--- a/Dockerfile.m1
+++ b/Dockerfile.m1
@@ -1,11 +1,15 @@
-FROM golang:1.16-stretch as build
+FROM golang:1.16-stretch as with-mem-mongo
+
+RUN wget https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian92-4.4.0.tgz
+RUN tar xzvf mongodb-linux-x86_64-debian92-4.4.0.tgz
+RUN mkdir -p /root/.cache/dp-mongodb-in-memory/mongodb-linux-x86_64-debian92-4.4.0.tgz/
+RUN mv mongodb-linux-x86_64-debian92-4.4.0/bin/mongod /root/.cache/dp-mongodb-in-memory/mongodb-linux-x86_64-debian92-4.4.0.tgz/
+
+FROM with-mem-mongo as build
 
 WORKDIR /service
 ADD . /service
-
-# RUN cd /service && go build -o /http-service .
-
-CMD make debug
+CMD tail -f /dev/null
 
 # TEST
 FROM build as test

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,17 @@ test-component:
 
 .PHONY: docker_test
 docker_test:
-	docker build -f Dockerfile.m1 . -t template_test --target=test
+	docker-compose -f docker-compose-m1.yml down
+	docker buildx build --platform linux/amd64 -f Dockerfile.m1 . -t template_test --target=test
 	docker-compose -f docker-compose-m1.yml up -d
-	docker-compose -f docker-compose-m1.yml exec -T http go test ./...
+	#docker-compose -f docker-compose-m1.yml exec -T http go test ./...
 	docker-compose -f docker-compose-m1.yml exec -T http go test -component
 	docker-compose -f docker-compose-m1.yml down
+
+.PHONY: test-coverage
+test-coverage:
+	rm combined-coverage.out component-coverage.out coverage.out
+	go test -cover ./... -coverprofile=coverage.out
+	go test -component -cover -coverpkg=github.com/ONSdigital/dp-files-api/... -coverprofile=component-coverage.out
+	gocovmerge coverage.out component-coverage.out > combined-coverage.out
+	go tool cover -html=combined-coverage.out

--- a/api/errors.go
+++ b/api/errors.go
@@ -38,6 +38,10 @@ func handleError(w http.ResponseWriter, err error) {
 	switch err {
 	case files.ErrDuplicateFile:
 		writeError(w, err, "DuplicateFileError", http.StatusBadRequest)
+	case files.ErrFileNotRegistered:
+		writeError(w, err, "FileNotRegistered", http.StatusNotFound)
+	case files.ErrFileNotInCreatedState:
+		writeError(w, err, "FileStateError", http.StatusConflict)
 	default:
 		writeError(w, err, "DatabaseError", http.StatusInternalServerError)
 	}

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -1,0 +1,7 @@
+package clock
+
+import "time"
+
+type Clock interface {
+	GetCurrentTime() time.Time
+}

--- a/clock/system.go
+++ b/clock/system.go
@@ -1,0 +1,9 @@
+package clock
+
+import "time"
+
+type SystemClock struct{}
+
+func (c SystemClock) GetCurrentTime() time.Time {
+	return time.Now()
+}

--- a/clock/system_test.go
+++ b/clock/system_test.go
@@ -1,0 +1,15 @@
+package clock
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestClockReturnsCurrentTime(t *testing.T) {
+	c := SystemClock{}
+	now := time.Now()
+	system := c.GetCurrentTime()
+	
+	assert.True(t, now.Before(system))
+}

--- a/docker-compose-m1.yml
+++ b/docker-compose-m1.yml
@@ -4,4 +4,4 @@ services:
   http:
     image: template_test
     ports:
-      - "8080:8080"
+      - "26900:26900"

--- a/features/mark_files_as_uploaded.feature
+++ b/features/mark_files_as_uploaded.feature
@@ -1,0 +1,56 @@
+Feature: Mark files as uploaded
+
+    As a file upload service
+    I want to register that i have complete upload of a file
+    So that download services know it is now available
+
+    Scenario: The one where marking upload complete is successful
+        Given the file upload "/images/meme.jpg" has been registered with:
+            | IsPublishable | true                                                                      |
+            | CollectionID  | 1234-asdfg-54321-qwerty                                                   |
+            | Title         | The latest Meme                                                           |
+            | SizeInBytes   | 14794                                                                     |
+            | Type          | image/jpeg                                                                |
+            | Licence       | OGL v3                                                                    |
+            | LicenceUrl    | http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+            | CreatedAt     | 2021-10-21T15:13:14Z                                                      |
+            | LastModified  | 2021-10-21T15:13:14Z                                                      |
+            | State         | CREATED                                                                   |
+        When the file upload "/images/meme.jpg" is marked as complete with the etag "123456789"
+        Then the HTTP status code should be "201"
+        And the following document entry should be look like:
+            | Path              | /images/meme.jpg                                                          |
+            | IsPublishable     | true                                                                      |
+            | CollectionID      | 1234-asdfg-54321-qwerty                                                   |
+            | Title             | The latest Meme                                                           |
+            | SizeInBytes       | 14794                                                                     |
+            | Type              | image/jpeg                                                                |
+            | Licence           | OGL v3                                                                    |
+            | LicenceUrl        | http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+            | CreatedAt         | 2021-10-21T15:13:14Z                                                      |
+            | LastModified      | 2021-10-19T09:30:30Z                                                      |
+            | UploadCompletedAt | 2021-10-19T09:30:30Z                                                      |
+            | Etag              | 123456789                                                                 |
+            | State             | UPLOADED                                                                  |
+
+#  Scenario: The one where the DB is down
+#
+    Scenario: Trying to mark an upload complete on a file that was not registered
+        Given the file upload "/images/meme.jpg" has not been registered
+        When the file upload "/images/meme.jpg" is marked as complete with the etag "123456789"
+        Then the HTTP status code should be "404"
+
+    Scenario: Trying to mark an upload complete on a file that is in the wrong state
+        Given the file upload "/images/meme.jpg" has been registered with:
+            | IsPublishable | true                                                                      |
+            | CollectionID  | 1234-asdfg-54321-qwerty                                                   |
+            | Title         | The latest Meme                                                           |
+            | SizeInBytes   | 14794                                                                     |
+            | Type          | image/jpeg                                                                |
+            | Licence       | OGL v3                                                                    |
+            | LicenceUrl    | http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+            | CreatedAt     | 2021-10-21T15:13:14Z                                                      |
+            | LastModified  | 2021-10-21T15:13:14Z                                                      |
+            | State         | UPLOADED                                                                  |
+        When the file upload "/images/meme.jpg" is marked as complete with the etag "123456789"
+        Then the HTTP status code should be "409"

--- a/features/register_files.feature
+++ b/features/register_files.feature
@@ -1,8 +1,8 @@
 Feature: Register new file upload
 
-    Scenario: Register that an upload has started
+  Scenario: Register that an upload has started
 
-        When the file upload is registered with payload:
+    When the file upload is registered with payload:
         """
         {
           "path": "/images/meme.jpg",
@@ -15,23 +15,23 @@ Feature: Register new file upload
           "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
         }
         """
-        Then the HTTP status code should be "201"
-        And the following document entry should be created:
-            | Path          | /images/meme.jpg                                                          |
-            | IsPublishable | true                                                                      |
-            | CollectionID  | 1234-asdfg-54321-qwerty                                                   |
-            | Title         | The latest Meme                                                           |
-            | SizeInBytes   | 14794                                                                     |
-            | Type          | image/jpeg                                                                |
-            | Licence       | OGL v3                                                                    |
-            | LicenceUrl    | http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
-            | CreatedAt     | 2021-10-19T09:01+00:00                                                    |
-            | LastModified  | 2021-10-19T09:01+00:00                                                    |
-            | State         | CREATED                                                                   |
+    Then the HTTP status code should be "201"
+    And the following document entry should be created:
+      | Path          | /images/meme.jpg                                                          |
+      | IsPublishable | true                                                                      |
+      | CollectionID  | 1234-asdfg-54321-qwerty                                                   |
+      | Title         | The latest Meme                                                           |
+      | SizeInBytes   | 14794                                                                     |
+      | Type          | image/jpeg                                                                |
+      | Licence       | OGL v3                                                                    |
+      | LicenceUrl    | http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+      | CreatedAt     | 2021-10-19T09:30:30Z                                                      |
+      | LastModified  | 2021-10-19T09:30:30Z                                                      |
+      | State         | CREATED                                                                   |
 
-    Scenario: Attempting to register a file with a path that is already register
-        Given the file upload "/images/old-meme.jpg" has been registered
-        When the file upload is registered with payload:
+  Scenario: Attempting to register a file with a path that is already register
+    Given the file upload "/images/old-meme.jpg" has been registered
+    When the file upload is registered with payload:
         """
         {
           "path": "/images/old-meme.jpg",
@@ -44,4 +44,4 @@ Feature: Register new file upload
           "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
         }
         """
-        Then the HTTP status code should be "400"
+    Then the HTTP status code should be "400"

--- a/features/steps/files_api_component.go
+++ b/features/steps/files_api_component.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/ONSdigital/dp-files-api/clock"
+
 	componenttest "github.com/ONSdigital/dp-component-test"
 	"github.com/ONSdigital/dp-files-api/config"
 	"github.com/ONSdigital/dp-files-api/mongo"
@@ -46,6 +48,17 @@ func (e *External) DoGetHTTPServer(bindAddr string, r http.Handler) service.HTTP
 	return e.Server
 }
 
+func (e External) DoGetClock(ctx context.Context) clock.Clock {
+	return testClock{}
+}
+
+type testClock struct{}
+
+func (tt testClock) GetCurrentTime() time.Time {
+	t, _ := time.Parse(time.RFC3339, "2021-10-19T09:30:30Z")
+	return t
+}
+
 func NewFilesApiComponent(murl string) *FilesApiComponent {
 	buf := bytes.NewBufferString("")
 	log.SetDestination(buf, buf)
@@ -82,7 +95,6 @@ func (d *FilesApiComponent) Initialiser() (http.Handler, error) {
 	cfg, _ := config.Get()
 	ctx := context.Background()
 	d.svc, _ = service.Run(ctx, cfg, d.svcList, "1", "1", "1", d.errChan)
-
 	return d.DpHttpServer.Handler, nil
 }
 

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -2,7 +2,11 @@ package steps
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"time"
+
+	"github.com/cucumber/messages-go/v16"
 
 	"github.com/ONSdigital/dp-files-api/files"
 	"github.com/cucumber/godog"
@@ -15,6 +19,12 @@ func (c *FilesApiComponent) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the file upload is registered with payload:`, c.iRegisterFile)
 	ctx.Step(`^the following document entry should be created:`, c.theFollowingDocumentShouldBeCreated)
 	ctx.Step(`^the file upload "([^"]*)" has been registered$`, c.theFileUploadHasBeenRegistered)
+	ctx.Step(`^the file upload "([^"]*)" has been registered with:$`, c.theFileUploadHasBeenRegisteredWith)
+	ctx.Step(`^the file upload "([^"]*)" is marked as complete with the etag "([^"]*)"$`, c.theFileUploadIsMarkedAsCompleteWithTheEtag)
+	ctx.Step(`^the following document entry should be look like:$`, c.theFollowingDocumentEntryShouldBeLookLike)
+	ctx.Step(`^the file upload "([^"]*)" has not been registered$`, c.theFileUploadHasNotBeenRegistered)
+
+
 }
 
 func (c *FilesApiComponent) iRegisterFile(payload *godog.DocString) error {
@@ -35,10 +45,16 @@ type ExpectedMetaData struct {
 	State         string
 }
 
+type ExpectedMetaDataUploadComplete struct {
+	ExpectedMetaData
+	Etag              string
+	UploadCompletedAt string
+}
+
 func (c *FilesApiComponent) theFollowingDocumentShouldBeCreated(table *godog.Table) error {
 	ctx := context.Background()
 
-	metaData := files.StoredMetaData{}
+	metaData := files.StoredRegisteredMetaData{}
 
 	assist := assistdog.NewDefault()
 	keyValues, err := assist.CreateInstance(&ExpectedMetaData{}, table)
@@ -61,6 +77,8 @@ func (c *FilesApiComponent) theFollowingDocumentShouldBeCreated(table *godog.Tab
 	assert.Equal(c.ApiFeature, expectedMetaData.Licence, metaData.Licence)
 	assert.Equal(c.ApiFeature, expectedMetaData.LicenceUrl, metaData.LicenceUrl)
 	assert.Equal(c.ApiFeature, expectedMetaData.State, metaData.State)
+	assert.Equal(c.ApiFeature, expectedMetaData.CreatedAt, metaData.CreatedAt.Format(time.RFC3339))
+	assert.Equal(c.ApiFeature, expectedMetaData.LastModified, metaData.LastModified.Format(time.RFC3339))
 
 	return c.ApiFeature.StepError()
 }
@@ -68,9 +86,100 @@ func (c *FilesApiComponent) theFollowingDocumentShouldBeCreated(table *godog.Tab
 func (c *FilesApiComponent) theFileUploadHasBeenRegistered(path string) error {
 	ctx := context.Background()
 
-	m := files.StoredMetaData{Path: path}
+	m := files.StoredRegisteredMetaData{Path: path}
+
 	_, err := c.Mongo.Client.Database("files").Collection("metadata").InsertOne(ctx, &m)
 	assert.NoError(c.ApiFeature, err)
+
+	return c.ApiFeature.StepError()
+}
+
+func (c *FilesApiComponent) theFileUploadHasBeenRegisteredWith(path string, table *godog.Table) error {
+	ctx := context.Background()
+	assist := assistdog.NewDefault()
+	keyValues, err := assist.CreateInstance(&ExpectedMetaData{}, table)
+	if err != nil {
+		return err
+	}
+
+	data := keyValues.(*ExpectedMetaData)
+
+	isPublishable, _ := strconv.ParseBool(data.IsPublishable)
+	sizeInBytes, _ := strconv.ParseUint(data.SizeInBytes, 10, 64)
+	createdAt, _ := time.Parse(time.RFC3339, data.CreatedAt)
+	lastModified, _ := time.Parse(time.RFC3339, data.LastModified)
+
+	m := files.StoredRegisteredMetaData{
+		Path:          path,
+		IsPublishable: isPublishable,
+		CollectionID:  data.CollectionID,
+		Title:         data.Title,
+		SizeInBytes:   sizeInBytes,
+		Type:          data.Type,
+		Licence:       data.Licence,
+		LicenceUrl:    data.LicenceUrl,
+		State:         data.State,
+		CreatedAt:     createdAt,
+		LastModified:  lastModified,
+	}
+	_, err = c.Mongo.Client.Database("files").Collection("metadata").InsertOne(ctx, &m)
+	assert.NoError(c.ApiFeature, err)
+
+	return c.ApiFeature.StepError()
+}
+
+func (c *FilesApiComponent) theFileUploadHasNotBeenRegistered(path string) error {
+	ctx := context.Background()
+	_, err := c.Mongo.Client.Database("files").Collection("metadata").DeleteMany(ctx, bson.M{"path": path})
+
+	assert.NoError(c.ApiFeature, err)
+
+	return c.ApiFeature.StepError()
+}
+
+
+func (c *FilesApiComponent) theFileUploadIsMarkedAsCompleteWithTheEtag(path, etag string) error {
+	json := fmt.Sprintf(`{
+	"path": "%s",
+	"etag": "%s"
+}`, path, etag)
+	payload := messages.PickleDocString{
+		MediaType: "application/json",
+		Content:   json,
+	}
+	return c.ApiFeature.IPostToWithBody("/v1/files/upload-complete", &payload)
+}
+
+func (c *FilesApiComponent) theFollowingDocumentEntryShouldBeLookLike(table *godog.Table) error {
+	ctx := context.Background()
+
+	metaData := files.StoredRegisteredMetaData{}
+
+	assist := assistdog.NewDefault()
+	keyValues, err := assist.CreateInstance(&ExpectedMetaDataUploadComplete{}, table)
+	if err != nil {
+		return err
+	}
+
+	expectedMetaData := keyValues.(*ExpectedMetaDataUploadComplete)
+
+	res := c.Mongo.Client.Database("files").Collection("metadata").FindOne(ctx, bson.M{"path": expectedMetaData.Path})
+	assert.NoError(c.ApiFeature, res.Decode(&metaData))
+
+	isPublishable, _ := strconv.ParseBool(expectedMetaData.IsPublishable)
+	sizeInBytes, _ := strconv.ParseUint(expectedMetaData.SizeInBytes, 10, 64)
+	assert.Equal(c.ApiFeature, isPublishable, metaData.IsPublishable)
+	assert.Equal(c.ApiFeature, expectedMetaData.CollectionID, metaData.CollectionID)
+	assert.Equal(c.ApiFeature, expectedMetaData.Title, metaData.Title)
+	assert.Equal(c.ApiFeature, sizeInBytes, metaData.SizeInBytes)
+	assert.Equal(c.ApiFeature, expectedMetaData.Type, metaData.Type)
+	assert.Equal(c.ApiFeature, expectedMetaData.Licence, metaData.Licence)
+	assert.Equal(c.ApiFeature, expectedMetaData.LicenceUrl, metaData.LicenceUrl)
+	assert.Equal(c.ApiFeature, expectedMetaData.State, metaData.State)
+	assert.Equal(c.ApiFeature, expectedMetaData.Etag, metaData.Etag)
+	assert.Equal(c.ApiFeature, expectedMetaData.CreatedAt, metaData.CreatedAt.Format(time.RFC3339))
+	assert.Equal(c.ApiFeature, expectedMetaData.LastModified, metaData.LastModified.Format(time.RFC3339))
+	assert.Equal(c.ApiFeature, expectedMetaData.UploadCompletedAt, metaData.UploadCompletedAt.Format(time.RFC3339))
 
 	return c.ApiFeature.StepError()
 }

--- a/files/metadata.go
+++ b/files/metadata.go
@@ -5,19 +5,26 @@ import (
 	"time"
 )
 
-type StoredMetaData struct {
-	Path          string    `bson:"path"`
-	IsPublishable bool      `bson:"is_publishable"`
-	CollectionID  string    `bson:"collection_id"`
-	Title         string    `bson:"title"`
-	SizeInBytes   uint64    `bson:"size_in_bytes"`
-	Type          string    `bson:"type"`
-	Licence       string    `bson:"licence"`
-	LicenceUrl    string    `bson:"licence_url"`
-	createdAt     time.Time `bson:"created_at"`
-	lastModified  time.Time `bson:"last_modified"`
-	State         string    `bson:"state"`
+type StoredRegisteredMetaData struct {
+	Path              string    `bson:"path"`
+	IsPublishable     bool      `bson:"is_publishable"`
+	CollectionID      string    `bson:"collection_id"`
+	Title             string    `bson:"title"`
+	SizeInBytes       uint64    `bson:"size_in_bytes"`
+	Type              string    `bson:"type"`
+	Licence           string    `bson:"licence"`
+	LicenceUrl        string    `bson:"licence_url"`
+	CreatedAt         time.Time `bson:"created_at"`
+	LastModified      time.Time `bson:"last_modified"`
+	UploadCompletedAt time.Time `bson:"upload_completed_at"`
+	State             string    `bson:"state"`
+	Etag              string    `bson:"etag"`
 }
 
-type CreateUploadStartedEntry func(ctx context.Context, metaData StoredMetaData) error
-type MakeUploadComplete func(path string) error
+type StoredUploadCompleteMetaData struct {
+	Path string `bson:"path"`
+	Etag string `bson:"etag"`
+}
+
+type CreateUploadStartedEntry func(ctx context.Context, metaData StoredRegisteredMetaData) error
+type MarkUploadComplete func(ctx context.Context, metaData StoredUploadCompleteMetaData) error

--- a/files/store.go
+++ b/files/store.go
@@ -3,24 +3,30 @@ package files
 import (
 	"context"
 	"errors"
+	"github.com/ONSdigital/dp-files-api/clock"
 	"github.com/ONSdigital/dp-files-api/mongo"
 	"go.mongodb.org/mongo-driver/bson"
-	"time"
 )
 
 var ErrDuplicateFile = errors.New("duplicate file path")
+var ErrFileNotRegistered = errors.New("file not registered")
+var ErrFileNotInCreatedState = errors.New("file state is not in state created")
+
+const (
+	stateCreated = "CREATED"
+	stateUploaded = "UPLOADED"
+)
 
 type Store struct {
 	m mongo.Client
+	c clock.Clock
 }
 
-func NewStore(m mongo.Client) *Store {
-	return &Store{m}
+func NewStore(m mongo.Client, c clock.Clock) *Store {
+	return &Store{m, c}
 }
 
-func (s *Store) CreateUploadStarted(ctx context.Context, metaData StoredMetaData) error {
-
-
+func (s *Store) CreateUploadStarted(ctx context.Context, metaData StoredRegisteredMetaData) error {
 	finder := s.m.Connection().C("metadata").Find(bson.M{"path": metaData.Path})
 	count, err := finder.Count(ctx)
 	if err != nil {
@@ -31,11 +37,46 @@ func (s *Store) CreateUploadStarted(ctx context.Context, metaData StoredMetaData
 		return ErrDuplicateFile
 	}
 
-	metaData.createdAt = time.Now()
-	metaData.lastModified = time.Now()
-	metaData.State = "CREATED"
+	metaData.CreatedAt = s.c.GetCurrentTime()
+	metaData.LastModified = s.c.GetCurrentTime()
+	metaData.State = stateCreated
 
 	_, err = s.m.Connection().C("metadata").Insert(ctx, metaData)
+
+	return err
+}
+
+func (s *Store) MarkUploadComplete(ctx context.Context, metaData StoredUploadCompleteMetaData) error {
+	finder := s.m.Connection().C("metadata").Find(bson.M{"path": metaData.Path})
+	count, err := finder.Count(ctx)
+	if err != nil {
+		return err
+	}
+
+	if count == 0 {
+		return ErrFileNotRegistered
+	}
+
+	m := StoredRegisteredMetaData{}
+	err = finder.One(ctx, &m)
+	if err != nil {
+		return err
+	}
+
+	if m.State != stateCreated {
+		return ErrFileNotInCreatedState
+	}
+
+	_, err = s.m.Connection().C("metadata").Update(
+		ctx,
+		bson.M{"path": metaData.Path},
+		bson.D{
+			{"$set", bson.D{
+				{"etag", metaData.Etag},
+				{"state", stateUploaded},
+				{"last_modified", s.c.GetCurrentTime()},
+				{"upload_completed_at", s.c.GetCurrentTime()}}},
+		})
 
 	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.1.7-beta // indirect
 	github.com/ONSdigital/dp-mongodb-in-memory v1.1.0 // indirect
 	github.com/cucumber/gherkin-go/v19 v19.0.3 // indirect
-	github.com/cucumber/messages-go/v16 v16.0.1 // indirect
+	github.com/cucumber/messages-go/v16 v16.0.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
@@ -62,7 +62,9 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.0
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-playground/validator v9.31.0+incompatible
+	github.com/google/gops v0.3.22 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
+	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad // indirect
 	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b // indirect
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
 	golang.org/x/sys v0.0.0-20211210111614-af8b64212486 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/ONSdigital/log.go/v2 v2.0.5/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snm
 github.com/ONSdigital/log.go/v2 v2.0.9 h1:dMtuN89vCP21iRuOBAGInn7ZzxIEGajC3o5pjoicnsY=
 github.com/ONSdigital/log.go/v2 v2.0.9/go.mod h1:VyTDkL82FtiAkaNFaT+bURBhLbP7NsIx4rkVbdpiuEg=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
+github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -105,6 +107,9 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/go-ole/go-ole v1.2.6-0.20210915003542-8b1f7f90f6b1 h1:4dntyT+x6QTOSCIrgczbQ+ockAEha0cfxD5Wi0iCzjY=
+github.com/go-ole/go-ole v1.2.6-0.20210915003542-8b1f7f90f6b1/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-playground/locales v0.14.0 h1:u50s323jtVGugKlcYeyzC0etD1HifMjqmJqb8WugfUU=
 github.com/go-playground/locales v0.14.0/go.mod h1:sawfccIbzZTqEDETgFXqTho0QybSa7l++s0DH+LDiLs=
 github.com/go-playground/universal-translator v0.18.0 h1:82dyy6p4OuJq4/CByFNOn/jYrnRPArHwAcmLoJZxyho=
@@ -169,6 +174,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/gops v0.3.22 h1:lyvhDxfPLHAOR2xIYwjPhN387qHxyU21Sk9sz/GhmhQ=
+github.com/google/gops v0.3.22/go.mod h1:7diIdLsqpCihPSX3fQagksT/Ku/y4RL9LHTlKyEUDl8=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -235,6 +242,8 @@ github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaR
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/keybase/go-ps v0.0.0-20190827175125-91aafc93ba19 h1:WjT3fLi9n8YWh/Ih8Q1LHAPsTqGddPcHqscN+PJ3i68=
+github.com/keybase/go-ps v0.0.0-20190827175125-91aafc93ba19/go.mod h1:hY+WOq6m2FpbvyrI93sMaypsttvaIL5nhVR92dTMUcQ=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -322,6 +331,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/shirou/gopsutil/v3 v3.21.9 h1:Vn4MUz2uXhqLSiCbGFRc0DILbMVLAY92DSkT8bsYrHg=
+github.com/shirou/gopsutil/v3 v3.21.9/go.mod h1:YWp/H8Qs5fVmf17v7JNZzA0mPJ+mS2e9JdiUF9LlKzQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -360,7 +371,13 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tklauser/go-sysconf v0.3.9 h1:JeUVdAOWhhxVcU6Eqr/ATFHgXk/mmiItdKeJPev3vTo=
+github.com/tklauser/go-sysconf v0.3.9/go.mod h1:11DU/5sG7UexIrp/O6g35hrWzu0JxlwQ3LSFUzyeuhs=
+github.com/tklauser/numcpus v0.3.0 h1:ILuRUQBtssgnxw0XXIjKUC56fgnOrFoQQ/4+DeU2biQ=
+github.com/tklauser/numcpus v0.3.0/go.mod h1:yFGUr7TUHQRAhyqBcEg0Ge34zDBAsIvJJcyE6boqnA8=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad h1:W0LEBv82YCGEtcmPA3uNZBI33/qF//HAAs3MawDjRa0=
+github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2 h1:akYIkZ28e6A96dkWNJQu3nmCzH3YfwMPQExUYDaRv7w=
@@ -371,6 +388,8 @@ github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhe
 github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/xlab/treeprint v1.1.0 h1:G/1DjNkPpfZCFt9CSh6b5/nY4VimlbHF3Rh4obvtzDk=
+github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a h1:fZHgsYlfvtyqToslyjUt3VOPF4J7aK/3MPcK7xp3PDk=
 github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a/go.mod h1:ul22v+Nro/R083muKhosV54bj5niojjWZvU8xrevuH4=
@@ -481,6 +500,7 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -492,6 +512,8 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210902050250-f475640dd07b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211210111614-af8b64212486 h1:5hpz5aRr+W1erYCL5JRhSUBJRph7l9XkNveoExlrKYk=
@@ -532,6 +554,7 @@ golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20210106214847-113979e3529a h1:CB3a9Nez8M13wwlr/E2YtwoU+qYHKfC+JrDa45RXXoQ=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -585,3 +608,5 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
+rsc.io/goversion v1.2.0 h1:SPn+NLTiAG7w30IRK/DKp1BjvpWabYgxlLp/+kx5J8w=
+rsc.io/goversion v1.2.0/go.mod h1:Eih9y/uIBS3ulggl7KNJ09xGSLcuNaLgmvvqa07sgfo=

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func run(ctx context.Context) error {
 	}
 
 	// Start service
-	svc, err := service.Run(ctx, cfg, svcList, BuildTime, GitCommit, Version, svcErrors)
+	svc, err := service.Run(ctx, cfg, svcList, "1", "1", "1", svcErrors)
 	if err != nil {
 		return errors.Wrap(err, "running service failed")
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"testing"
 
@@ -72,6 +73,10 @@ func TestComponent(t *testing.T) {
 			TestSuiteInitializer: f.InitializeTestSuite,
 			Options:              &opts,
 		}.Run()
+
+		fmt.Println("=================================")
+		fmt.Printf("Component test coverage: %.2f%%\n", testing.Coverage()*100)
+		fmt.Println("=================================")
 
 		if status > 0 {
 			t.Fail()

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	connectTimeoutInSeconds = 5
-	queryTimeoutInSeconds   = 15
+	queryTimeoutInSeconds   = 5
 )
 
 //go:generate moq -out mock/Client.go -pkg mock . Client

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -2,9 +2,11 @@ package service
 
 import (
 	"context"
+	"net/http"
+
+	"github.com/ONSdigital/dp-files-api/clock"
 	"github.com/ONSdigital/dp-files-api/mongo"
 	"github.com/ONSdigital/log.go/v2/log"
-	"net/http"
 
 	"github.com/ONSdigital/dp-files-api/config"
 
@@ -55,6 +57,10 @@ func (e *ExternalServiceList) GetMongoDB(ctx context.Context, cfg *config.Config
 	return db, nil
 }
 
+func (e *ExternalServiceList) GetClock(ctx context.Context) clock.Clock {
+	return e.Init.DoGetClock(ctx)
+}
+
 // DoGetHTTPServer creates an HTTP Server with the provided bind address and router
 func (e *Init) DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer {
 	s := dphttp.NewServer(bindAddr, router)
@@ -80,4 +86,8 @@ func (e *Init) DoGetMongoDB(ctx context.Context, cfg *config.Config) (mongo.Clie
 		return mongodb, err
 	}
 	return mongodb, nil
+}
+
+func (e *Init) DoGetClock(ctx context.Context) clock.Clock {
+	return clock.SystemClock{}
 }

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
-	"github.com/ONSdigital/dp-files-api/mongo"
 	"net/http"
+
+	"github.com/ONSdigital/dp-files-api/clock"
+	"github.com/ONSdigital/dp-files-api/mongo"
 
 	"github.com/ONSdigital/dp-files-api/config"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
@@ -18,6 +20,7 @@ type Initialiser interface {
 	DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer
 	DoGetHealthCheck(cfg *config.Config, buildTime, gitCommit, version string) (HealthChecker, error)
 	DoGetMongoDB(ctx context.Context, cfg *config.Config) (mongo.Client, error)
+	DoGetClock(ctx context.Context) clock.Clock
 }
 
 // HTTPServer defines the required methods from the HTTP server
@@ -33,5 +36,3 @@ type HealthChecker interface {
 	Stop()
 	AddCheck(name string, checker healthcheck.Checker) (err error)
 }
-
-

--- a/service/service.go
+++ b/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+
 	"github.com/ONSdigital/dp-files-api/api"
 	"github.com/ONSdigital/dp-files-api/config"
 	"github.com/ONSdigital/dp-files-api/files"
@@ -36,9 +37,10 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 
 	// Get HTTP Server and ... // TODO: Add any middleware that your service requires
 	r := mux.NewRouter()
-	store := files.NewStore(mongoClient)
+	store := files.NewStore(mongoClient, serviceList.GetClock(ctx))
 
 	r.StrictSlash(true).Path("/v1/files").HandlerFunc(api.CreateFileUploadStartedHandler(store.CreateUploadStarted))
+	r.StrictSlash(true).Path("/v1/files/upload-complete").HandlerFunc(api.MarkUploadCompleteHandler(store.MarkUploadComplete))
 
 	s := serviceList.GetHTTPServer(cfg.BindAddr, r)
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -9,7 +9,9 @@ info:
 
 schemes:
   - http
-  -
+
+basePath: http://localhost:26900/
+
 tags:
   - name: "private"
 
@@ -23,6 +25,23 @@ paths:
         - application/json
       parameters:
         - $ref: '#/parameters/new_file_upload'
+      responses:
+        201:
+          description: OK
+        400:
+          $ref: '#/responses/JsonErrors'
+        500:
+          $ref: '#/responses/InternalError'
+
+  /v1/files/upload-complete:
+    post:
+      tags:
+        - File upload complete
+      summary: POST's metadata for a file when an upload has completed
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/file_upload_complete'
       responses:
         201:
           description: OK
@@ -53,10 +72,10 @@ responses:
   InternalError:
     description: "Failed to process the request due to an internal error"
   JsonErrors:
-      type: object
-      description: "Common error response format"
-      schema:
-        $ref: "#/definitions/Error"
+    type: object
+    description: "Common error response format"
+    schema:
+      $ref: "#/definitions/Error"
 
 definitions:
   RegisterFileUploadResponse:
@@ -179,6 +198,21 @@ definitions:
         type: string
         description: "Licence URL"
         example: "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+  FileUploadComplete:
+    type: object
+    description: "File upload complete metadata to be POSTed"
+    required:
+      - "path"
+      - "etag"
+    properties:
+      path:
+        type: string
+        description: "Path to file"
+        example: "/images/meme.jpg"
+      etag:
+        type: string
+        description: "The etag for the file"
+        example: "194577a7e20bdcc7afbb718f502c134c"
   Error:
     type: object
     properties:
@@ -202,3 +236,11 @@ parameters:
     required: true
     schema:
       $ref: '#/definitions/NewFileUpload'
+
+  file_upload_complete:
+    name: new_file_upload
+    description: "Register that a file upload has completed"
+    in: body
+    required: true
+    schema:
+      $ref: '#/definitions/FileUploadComplete'


### PR DESCRIPTION
### What

This PR adds a new endpoint for marking a file upload as completed so that download service can know whether the file is available for public consumption

### How to review

Run example of following curl request against service in `develop`
```sh
curl -X 'POST' \                                      
  'http://localhost:26900/v1/files/upload-complete' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "path": "/images/meme.jpg",
  "etag": "194577a7e20bdcc7afbb718f502c134c"
}' 
```

### Who can review

Anyone
