### PR TITLE
check for published collections

### DIFF
--- a/store/collection_operations.go
+++ b/store/collection_operations.go
@@ -33,7 +33,7 @@ func (store *Store) UpdateCollectionID(ctx context.Context, path, collectionID s
 
 	//check to see if collectionID exists and is not-published
 	m := files.StoredRegisteredMetaData{}
-	if err := store.mongoCollection.FindOne(ctx, bson.M{fieldCollectionID: collectionID}, &m); err != nil {
+	if err := store.mongoCollection.FindOne(ctx, bson.M{fieldCollectionID: collectionID}, &m); err != nil && !errors.Is(err, mongodriver.ErrNoDocumentFound) {
 		log.Error(ctx, "update collection ID: caught db error", err, logdata)
 		return err
 	}

--- a/store/collection_operations.go
+++ b/store/collection_operations.go
@@ -33,13 +33,16 @@ func (store *Store) UpdateCollectionID(ctx context.Context, path, collectionID s
 
 	//check to see if collectionID exists and is not-published
 	m := files.StoredRegisteredMetaData{}
-	err := store.mongoCollection.FindOne(ctx, bson.M{fieldCollectionID: collectionID}, &m)
-	if err == nil && m.State == StatePublished {
+	if err := store.mongoCollection.FindOne(ctx, bson.M{fieldCollectionID: collectionID}, &m); err != nil {
+		log.Error(ctx, "update collection ID: caught db error", err, logdata)
+		return err
+	}
+	if m.State == StatePublished || m.State == StateDecrypted {
 		log.Error(ctx, fmt.Sprintf("collection with id [%s] is already published", collectionID), ErrCollectionAlreadyPublished, logdata)
 		return ErrCollectionAlreadyPublished
 	}
 
-	_, err = store.mongoCollection.Update(
+	_, err := store.mongoCollection.Update(
 		ctx,
 		bson.M{"path": path},
 		bson.D{

--- a/store/collection_operations_test.go
+++ b/store/collection_operations_test.go
@@ -75,6 +75,7 @@ func (suite *StoreSuite) TestUpdateCollectionIDCollectionIDAlreadySet() {
 
 func (suite *StoreSuite) TestUpdateCollectionIDUpdateReturnsError() {
 	metadata := suite.generateMetadata("")
+	metadata.State = store.StateUploaded
 	metadata.CollectionID = nil
 	metadataBytes, _ := bson.Marshal(metadata)
 
@@ -95,6 +96,7 @@ func (suite *StoreSuite) TestUpdateCollectionIDUpdateReturnsError() {
 
 func (suite *StoreSuite) TestUpdateCollectionIDUpdateSuccess() {
 	metadata := suite.generateMetadata("")
+	metadata.State = store.StateUploaded
 	metadata.CollectionID = nil
 	metadataBytes, _ := bson.Marshal(metadata)
 

--- a/store/errors.go
+++ b/store/errors.go
@@ -3,13 +3,14 @@ package store
 import "errors"
 
 var (
-	ErrDuplicateFile           = errors.New("duplicate file path")
-	ErrFileNotRegistered       = errors.New("file not registered")
-	ErrFileNotInCreatedState   = errors.New("file state is not in state created")
-	ErrFileNotInUploadedState  = errors.New("file state is not in state uploaded")
-	ErrFileNotInPublishedState = errors.New("file state is not in state published")
-	ErrFileIsNotPublishable    = errors.New("file is not set as publishable")
-	ErrNoFilesInCollection     = errors.New("no files found in collection")
-	ErrCollectionIDAlreadySet  = errors.New("collection ID already set")
-	ErrCollectionIDNotSet      = errors.New("collection ID not set")
+	ErrDuplicateFile              = errors.New("duplicate file path")
+	ErrFileNotRegistered          = errors.New("file not registered")
+	ErrFileNotInCreatedState      = errors.New("file state is not in state created")
+	ErrFileNotInUploadedState     = errors.New("file state is not in state uploaded")
+	ErrFileNotInPublishedState    = errors.New("file state is not in state published")
+	ErrFileIsNotPublishable       = errors.New("file is not set as publishable")
+	ErrNoFilesInCollection        = errors.New("no files found in collection")
+	ErrCollectionIDAlreadySet     = errors.New("collection ID already set")
+	ErrCollectionIDNotSet         = errors.New("collection ID not set")
+	ErrCollectionAlreadyPublished = errors.New("collection with the given id is already published")
 )

--- a/store/state_changes.go
+++ b/store/state_changes.go
@@ -27,8 +27,11 @@ func (store *Store) RegisterFileUpload(ctx context.Context, metaData files.Store
 	//check to see if collectionID exists and is not-published
 	if metaData.CollectionID != nil {
 		m := files.StoredRegisteredMetaData{}
-		err := store.mongoCollection.FindOne(ctx, bson.M{fieldCollectionID: *metaData.CollectionID}, &m)
-		if err == nil && m.State == StatePublished {
+		if err := store.mongoCollection.FindOne(ctx, bson.M{fieldCollectionID: *metaData.CollectionID}, &m); err != nil {
+			log.Error(ctx, "register file upload: caught db error", err, logdata)
+			return err
+		}
+		if m.State == StatePublished || m.State == StateDecrypted {
 			log.Error(ctx, fmt.Sprintf("collection with id [%s] is already published", *metaData.CollectionID), ErrCollectionAlreadyPublished, logdata)
 			return ErrCollectionAlreadyPublished
 		}

--- a/store/state_changes.go
+++ b/store/state_changes.go
@@ -27,7 +27,7 @@ func (store *Store) RegisterFileUpload(ctx context.Context, metaData files.Store
 	//check to see if collectionID exists and is not-published
 	if metaData.CollectionID != nil {
 		m := files.StoredRegisteredMetaData{}
-		if err := store.mongoCollection.FindOne(ctx, bson.M{fieldCollectionID: *metaData.CollectionID}, &m); err != nil {
+		if err := store.mongoCollection.FindOne(ctx, bson.M{fieldCollectionID: *metaData.CollectionID}, &m); err != nil && !errors.Is(err, mongodriver.ErrNoDocumentFound) {
 			log.Error(ctx, "register file upload: caught db error", err, logdata)
 			return err
 		}

--- a/store/state_changes_test.go
+++ b/store/state_changes_test.go
@@ -39,6 +39,7 @@ func (suite *StoreSuite) TestRegisterFileUploadWhenFilePathAlreadyExists() {
 	defer suite.logInterceptor.Stop()
 
 	metadata := suite.generateMetadata(suite.defaultCollectionID)
+	metadata.State = store.StateUploaded
 	expectedError := mongo.WriteError{Code: 11000}
 	metadataBytes, _ := bson.Marshal(metadata)
 
@@ -89,6 +90,7 @@ func (suite *StoreSuite) TestRegisterFileUploadInsertReturnsError() {
 	defer suite.logInterceptor.Stop()
 
 	metadata := suite.generateMetadata(suite.defaultCollectionID)
+	metadata.State = store.StateUploaded
 	expectedError := errors.New("error occurred")
 	metadataBytes, _ := bson.Marshal(metadata)
 
@@ -112,6 +114,7 @@ func (suite *StoreSuite) TestRegisterFileUploadInsertSucceeds() {
 	defer suite.logInterceptor.Stop()
 
 	metadata := suite.generateMetadata(suite.defaultCollectionID)
+	metadata.State = store.StateUploaded
 	metadataBytes, _ := bson.Marshal(metadata)
 
 	collectionCountReturnsZero := mock.MongoCollectionMock{


### PR DESCRIPTION
A collection has an ID which cannot be reused. In this case when a file is added to the fileAPI is has an associated collection id, we need to check that the collection Id has not been previously used, i.e. there is not an existing record with that collection Id that is not in a published state