### PR TITLE
speed up collection publishing

### DIFF
--- a/api/get_metadatas.go
+++ b/api/get_metadatas.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/ONSdigital/dp-files-api/files"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 type GetFilesMetadata func(ctx context.Context, collectionID string) ([]files.StoredRegisteredMetaData, error)
@@ -23,6 +24,7 @@ func HandlerGetFilesMetadata(getFilesMetadata GetFilesMetadata) http.HandlerFunc
 
 		fm, err := getFilesMetadata(req.Context(), collectionID)
 		if err != nil {
+			log.Error(req.Context(), "file metadata fetch failed", err, log.Data{"collection": collectionID})
 			handleError(w, err)
 			return
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -46,7 +46,10 @@ type KafkaConfig struct {
 
 var cfg *Config
 
-const MetadataCollection = "MetadataCollection"
+const (
+	MetadataCollection    = "MetadataCollection"
+	CollectionsCollection = "CollectionsCollection"
+)
 
 // Get returns the default config with any modifications through environment
 // variables
@@ -67,9 +70,12 @@ func Get() (*Config, error) {
 		MaxNumBatches:              5,
 		MinBatchSize:               20,
 		MongoConfig: MongoConfig{
-			ClusterEndpoint:               "localhost:27017",
-			Database:                      "files",
-			Collections:                   map[string]string{MetadataCollection: "metadata"},
+			ClusterEndpoint: "localhost:27017",
+			Database:        "files",
+			Collections: map[string]string{
+				MetadataCollection:    "metadata",
+				CollectionsCollection: "collections",
+			},
 			IsStrongReadConcernEnabled:    false,
 			IsWriteConcernMajorityEnabled: true,
 			ConnectTimeout:                5 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,7 +34,7 @@ func TestConfig(t *testing.T) {
 				So(testCfg.MinBatchSize, ShouldEqual, 20)
 				So(testCfg.MongoConfig.ClusterEndpoint, ShouldEqual, "localhost:27017")
 				So(testCfg.MongoConfig.Database, ShouldEqual, "files")
-				So(testCfg.MongoConfig.Collections, ShouldResemble, map[string]string{MetadataCollection: "metadata"})
+				So(testCfg.MongoConfig.Collections, ShouldResemble, map[string]string{MetadataCollection: "metadata", CollectionsCollection: "collections"})
 				So(testCfg.MongoConfig.IsStrongReadConcernEnabled, ShouldEqual, false)
 				So(testCfg.MongoConfig.IsWriteConcernMajorityEnabled, ShouldEqual, true)
 				So(testCfg.MongoConfig.ConnectTimeout, ShouldEqual, 5*time.Second)

--- a/features/steps/files_api_component.go
+++ b/features/steps/files_api_component.go
@@ -78,6 +78,15 @@ func (d *FilesApiComponent) Reset() {
 			Options: options.Index().SetUnique(true),
 		},
 	)
+	d.mongoClient.Database("files").Collection("collections").Drop(ctx)
+	d.mongoClient.Database("files").CreateCollection(ctx, "collections")
+	d.mongoClient.Database("files").Collection("collections").Indexes().CreateOne(
+		ctx,
+		mongo.IndexModel{
+			Keys:    bson.D{{"id", 1}},
+			Options: options.Index().SetUnique(true),
+		},
+	)
 	d.isPublishing = true
 }
 

--- a/files/metadata.go
+++ b/files/metadata.go
@@ -22,6 +22,13 @@ type StoredRegisteredMetaData struct {
 	Etag              string     `bson:"etag" json:"etag"`
 }
 
+type StoredCollection struct {
+	ID           string     `bson:"id" json:"id"`
+	State        string     `bson:"state" json:"state"`
+	LastModified time.Time  `bson:"last_modified" json:"-"`
+	PublishedAt  *time.Time `bson:"published_at,omitempty" json:"-"`
+}
+
 type FileEtagChange struct {
 	Path string
 	Etag string

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -34,7 +34,11 @@ func New(cfg config.MongoConfig) (m *Mongo, err error) {
 	}
 
 	databaseCollectionBuilder := map[mongohealth.Database][]mongohealth.Collection{
-		mongohealth.Database(m.Database): {mongohealth.Collection(m.ActualCollectionName(config.MetadataCollection))}}
+		mongohealth.Database(m.Database): {
+			mongohealth.Collection(m.ActualCollectionName(config.MetadataCollection)),
+			mongohealth.Collection(m.ActualCollectionName(config.CollectionsCollection)),
+		},
+	}
 	m.healthClient = mongohealth.NewClientWithCollections(m.conn, databaseCollectionBuilder)
 
 	return m, nil

--- a/mongodb/entrypoint-initdb.d/init.js
+++ b/mongodb/entrypoint-initdb.d/init.js
@@ -1,7 +1,7 @@
 var databases = [
     {
         name: "files",
-        collections: ["metadata"]
+        collections: ["metadata", "collections"]
     }
 ];
 

--- a/service/service.go
+++ b/service/service.go
@@ -44,7 +44,14 @@ func Run(ctx context.Context, serviceList ServiceContainer, svcErrors chan error
 	hc := serviceList.GetHealthCheck()
 	authMiddleware := serviceList.GetAuthMiddleware()
 	s3Client := serviceList.GetS3Clienter()
-	store := store.NewStore(mongoClient.Collection(config.MetadataCollection), kafkaProducer, serviceList.GetClock(), s3Client, cfg)
+	store := store.NewStore(
+		mongoClient.Collection(config.MetadataCollection),
+		mongoClient.Collection(config.CollectionsCollection),
+		kafkaProducer,
+		serviceList.GetClock(),
+		s3Client,
+		cfg,
+	)
 
 	getSingleFile := api.HandleGetFileMetadata(store.GetFileMetadata)
 

--- a/store/fields.go
+++ b/store/fields.go
@@ -1,6 +1,7 @@
 package store
 
 const (
+	fieldID                = "id"
 	fieldPath              = "path"
 	fieldCollectionID      = "collection_id"
 	fieldEtag              = "etag"

--- a/store/integration_test.go
+++ b/store/integration_test.go
@@ -3,8 +3,9 @@ package store_test
 import (
 	"context"
 	"flag"
-	"github.com/ONSdigital/dp-files-api/store"
 	"testing"
+
+	"github.com/ONSdigital/dp-files-api/store"
 
 	"github.com/ONSdigital/dp-files-api/config"
 	"github.com/ONSdigital/dp-files-api/features/steps"
@@ -46,7 +47,7 @@ func (s *StoreIntegrationTest) SetupTest() {
 	client.Database("files").Collection("metadata").Drop(s.ctx)
 
 	cfg, _ := config.Get()
-	s.store = store.NewStore(s.mc.Collection(config.MetadataCollection), &kafkatest.IProducerMock{}, steps.TestClock{}, nil, cfg)
+	s.store = store.NewStore(s.mc.Collection(config.MetadataCollection), s.mc.Collection(config.CollectionsCollection), &kafkatest.IProducerMock{}, steps.TestClock{}, nil, cfg)
 }
 
 func TestStoreIntegration(t *testing.T) {

--- a/store/metadata_retrieval.go
+++ b/store/metadata_retrieval.go
@@ -13,18 +13,84 @@ import (
 func (store *Store) GetFileMetadata(ctx context.Context, path string) (files.StoredRegisteredMetaData, error) {
 	metadata := files.StoredRegisteredMetaData{}
 
-	err := store.mongoCollection.FindOne(ctx, bson.M{fieldPath: path}, &metadata)
-	if err != nil && errors.Is(err, mongodriver.ErrNoDocumentFound) {
-		log.Error(ctx, "file metadata not found", err, log.Data{"path": path})
-		return metadata, ErrFileNotRegistered
+	err := store.metadataCollection.FindOne(ctx, bson.M{fieldPath: path}, &metadata)
+	if err != nil {
+		if errors.Is(err, mongodriver.ErrNoDocumentFound) {
+			log.Error(ctx, "file metadata not found", err, log.Data{"path": path})
+			return metadata, ErrFileNotRegistered
+		}
+		return metadata, err
 	}
 
-	return metadata, err
+	// pre-check to avoid fetching collection if it's not necessary
+	if metadata.CollectionID == nil || metadata.State != StateUploaded {
+		return metadata, nil
+	}
+
+	collection, err := store.GetCollection(ctx, *metadata.CollectionID)
+	if err != nil {
+		return metadata, err
+	}
+
+	store.PatchMetadataWithCollectionInfo(&metadata, &collection)
+
+	return metadata, nil
 }
 
 func (store *Store) GetFilesMetadata(ctx context.Context, collectionID string) ([]files.StoredRegisteredMetaData, error) {
 	files := make([]files.StoredRegisteredMetaData, 0)
-	_, err := store.mongoCollection.Find(ctx, bson.M{fieldCollectionID: collectionID}, &files)
+	_, err := store.metadataCollection.Find(ctx, bson.M{fieldCollectionID: collectionID}, &files)
+	if err != nil {
+		return nil, err
+	}
 
-	return files, err
+	collection, err := store.GetCollection(ctx, collectionID)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < len(files); i++ {
+		store.PatchMetadataWithCollectionInfo(&files[i], &collection)
+	}
+
+	return files, nil
+}
+
+func (store *Store) GetCollection(ctx context.Context, id string) (files.StoredCollection, error) {
+	collection := files.StoredCollection{}
+	err := store.collectionsCollection.FindOne(ctx, bson.M{fieldID: id}, &collection)
+	if err != nil {
+		log.Error(ctx, "collection metadata not found", err, log.Data{"id": id})
+	}
+	return collection, err
+}
+
+// For the optimisation purposes, we store the Florence collection publishing information in a separate DB collection.
+// Because of this, we need to patch the file metadata in a specific case documented below.
+func (store *Store) PatchMetadataWithCollectionInfo(metadata *files.StoredRegisteredMetaData, collection *files.StoredCollection) {
+	if metadata == nil || collection == nil {
+		return
+	}
+	// sanity check - collection data should only apply if the collection of the file matches
+	// the collection passed in the parameter
+	if metadata.CollectionID == nil || *metadata.CollectionID != collection.ID {
+		return
+	}
+
+	// collection state should only affect the file metadata if the file is in uploaded state
+	if metadata.State != StateUploaded {
+		return
+	}
+	// collection state should only affect the file metadata if the collection is in published state
+	if collection.State != StatePublished {
+		return
+	}
+
+	// We now know the file is uploaded and the collection is published. This means the file
+	// should be considered published.
+	// Also, collection publishing always happens after uploading the file and so the publishing
+	// and modification date of the file should be adjusted to match that of the collection.
+	metadata.State = StatePublished
+	metadata.PublishedAt = collection.PublishedAt
+	metadata.LastModified = collection.LastModified
 }

--- a/store/metadata_retrieval.go
+++ b/store/metadata_retrieval.go
@@ -29,7 +29,7 @@ func (store *Store) GetFileMetadata(ctx context.Context, path string) (files.Sto
 
 	collection, err := store.GetCollection(ctx, *metadata.CollectionID)
 	if err != nil {
-		return metadata, err
+		return metadata, nil
 	}
 
 	store.PatchMetadataWithCollectionInfo(&metadata, &collection)
@@ -46,7 +46,7 @@ func (store *Store) GetFilesMetadata(ctx context.Context, collectionID string) (
 
 	collection, err := store.GetCollection(ctx, collectionID)
 	if err != nil {
-		return nil, err
+		return files, nil
 	}
 
 	for i := 0; i < len(files); i++ {
@@ -61,6 +61,7 @@ func (store *Store) GetCollection(ctx context.Context, id string) (files.StoredC
 	err := store.collectionsCollection.FindOne(ctx, bson.M{fieldID: id}, &collection)
 	if err != nil {
 		log.Error(ctx, "collection metadata not found", err, log.Data{"id": id})
+		return files.StoredCollection{}, err
 	}
 	return collection, err
 }

--- a/store/metadata_retrieval.go
+++ b/store/metadata_retrieval.go
@@ -27,7 +27,7 @@ func (store *Store) GetFileMetadata(ctx context.Context, path string) (files.Sto
 		return fileMetadata, nil
 	}
 
-	// if the collection is published, get its metadata
+	// get the collection metadata, and if they're not present, return the file unchanged
 	collectionPublishedMetadata, err := store.GetCollectionPublishedMetadata(ctx, *fileMetadata.CollectionID)
 	if err != nil {
 		return fileMetadata, nil
@@ -46,7 +46,7 @@ func (store *Store) GetFilesMetadata(ctx context.Context, collectionID string) (
 		return nil, err
 	}
 
-	// if the collection is published, get its metadata
+	// get the collection metadata, and if they're not present, return the files unchanged
 	collection, err := store.GetCollectionPublishedMetadata(ctx, collectionID)
 	if err != nil {
 		return files, nil

--- a/store/metadata_retrieval_test.go
+++ b/store/metadata_retrieval_test.go
@@ -79,7 +79,7 @@ func (suite *StoreSuite) TestGetFileMetadataCollectionError() {
 	logEvent := suite.logInterceptor.GetLogEvent()
 
 	suite.Equal("collection metadata not found", logEvent)
-	suite.EqualError(err, "collection error")
+	suite.NoError(err)
 	suite.Exactly(expectedMetadata, actualMetadata)
 }
 
@@ -220,9 +220,10 @@ func (suite *StoreSuite) TestGetFilesMetadataFindError() {
 }
 
 func (suite *StoreSuite) TestGetFilesMetadataCollectionError() {
+	metadata := suite.generateMetadata(suite.defaultCollectionID)
 	metadataColl := mock.MongoCollectionMock{
 		FindFunc: CollectionFindReturnsMetadataOnFilter(
-			[]files.StoredRegisteredMetaData{},
+			[]files.StoredRegisteredMetaData{metadata},
 			bson.M{"collection_id": suite.defaultCollectionID},
 		),
 	}
@@ -235,8 +236,8 @@ func (suite *StoreSuite) TestGetFilesMetadataCollectionError() {
 
 	actualMetadata, err := subject.GetFilesMetadata(suite.defaultContext, suite.defaultCollectionID)
 
-	suite.EqualError(err, "collection error")
-	suite.Nil(actualMetadata)
+	suite.NoError(err)
+	suite.Exactly([]files.StoredRegisteredMetaData{metadata}, actualMetadata)
 }
 
 func (suite *StoreSuite) TestPatchMetadataNilMetadata() {
@@ -245,7 +246,7 @@ func (suite *StoreSuite) TestPatchMetadataNilMetadata() {
 	var metadata *files.StoredRegisteredMetaData
 	collection := &files.StoredCollection{}
 
-	subject.PatchMetadataWithCollectionInfo(metadata, collection)
+	subject.PatchFilePublishMetadata(metadata, collection)
 	suite.Nil(metadata)
 }
 
@@ -260,7 +261,7 @@ func (suite *StoreSuite) TestPatchMetadataNilCollection() {
 	}
 	metadataExpected := metadata
 
-	subject.PatchMetadataWithCollectionInfo(&metadata, nil)
+	subject.PatchFilePublishMetadata(&metadata, nil)
 	suite.Exactly(metadataExpected, metadata)
 }
 
@@ -278,7 +279,7 @@ func (suite *StoreSuite) TestPatchMetadataNilCollectionID() {
 
 	metadataExpected := metadata
 
-	subject.PatchMetadataWithCollectionInfo(&metadata, collection)
+	subject.PatchFilePublishMetadata(&metadata, collection)
 	suite.Exactly(metadataExpected, metadata)
 }
 
@@ -298,7 +299,7 @@ func (suite *StoreSuite) TestPatchMetadataCollectionIDMismatch() {
 
 	metadataExpected := metadata
 
-	subject.PatchMetadataWithCollectionInfo(&metadata, collection)
+	subject.PatchFilePublishMetadata(&metadata, collection)
 	suite.Exactly(metadataExpected, metadata)
 }
 
@@ -318,7 +319,7 @@ func (suite *StoreSuite) TestPatchMetadataBadState() {
 
 	metadataExpected := metadata
 
-	subject.PatchMetadataWithCollectionInfo(&metadata, collection)
+	subject.PatchFilePublishMetadata(&metadata, collection)
 	suite.Exactly(metadataExpected, metadata)
 }
 
@@ -337,7 +338,7 @@ func (suite *StoreSuite) TestPatchMetadataBadCollectionState() {
 
 	metadataExpected := metadata
 
-	subject.PatchMetadataWithCollectionInfo(&metadata, collection)
+	subject.PatchFilePublishMetadata(&metadata, collection)
 	suite.Exactly(metadataExpected, metadata)
 }
 
@@ -367,6 +368,6 @@ func (suite *StoreSuite) TestPatchMetadataSuccess() {
 		LastModified: lastModified,
 	}
 
-	subject.PatchMetadataWithCollectionInfo(&metadata, collection)
+	subject.PatchFilePublishMetadata(&metadata, collection)
 	suite.Exactly(metadataExpected, metadata)
 }

--- a/store/metadata_retrieval_test.go
+++ b/store/metadata_retrieval_test.go
@@ -1,6 +1,8 @@
 package store_test
 
 import (
+	"errors"
+
 	"github.com/ONSdigital/dp-files-api/config"
 	"github.com/ONSdigital/dp-files-api/files"
 	"github.com/ONSdigital/dp-files-api/mongo/mock"
@@ -9,7 +11,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-func (suite *StoreSuite) TestGetFileMetadataError() {
+func (suite *StoreSuite) TestGetFileMetadataNotFoundError() {
 	suite.logInterceptor.Start()
 	defer suite.logInterceptor.Stop()
 
@@ -18,7 +20,7 @@ func (suite *StoreSuite) TestGetFileMetadataError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	_, err := subject.GetFileMetadata(suite.defaultContext, suite.path)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -27,7 +29,19 @@ func (suite *StoreSuite) TestGetFileMetadataError() {
 	suite.Equal(store.ErrFileNotRegistered, err)
 }
 
-func (suite *StoreSuite) TestGetFileMetadataSuccess() {
+func (suite *StoreSuite) TestGetFileMetadataOtherError() {
+	collection := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(errors.New("find error")),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(&collection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	_, err := subject.GetFileMetadata(suite.defaultContext, suite.path)
+
+	suite.EqualError(err, "find error")
+}
+
+func (suite *StoreSuite) TestGetFileMetadataNoCollectionPatching() {
 	expectedMetadata := suite.generateMetadata(suite.defaultCollectionID)
 
 	metadataBytes, _ := bson.Marshal(expectedMetadata)
@@ -37,42 +51,322 @@ func (suite *StoreSuite) TestGetFileMetadataSuccess() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	actualMetadata, _ := subject.GetFileMetadata(suite.defaultContext, suite.path)
 
 	suite.Exactly(expectedMetadata, actualMetadata)
 }
 
-func (suite *StoreSuite) TestGetFilesMetadataSuccessSingleResult() {
-	metadata := suite.generateMetadata(suite.defaultCollectionID)
-	metadataBytes, _ := bson.Marshal(metadata)
+func (suite *StoreSuite) TestGetFileMetadataCollectionError() {
+	suite.logInterceptor.Start()
+	defer suite.logInterceptor.Stop()
 
-	collection := mock.MongoCollectionMock{
-		FindFunc: CollectionFindSetsResultAndReturns1IfCollectionIDMatchesFilter(metadataBytes),
+	expectedMetadata := suite.generateMetadata(suite.defaultCollectionID)
+	expectedMetadata.State = store.StateUploaded
+	metadataBytes, _ := bson.Marshal(expectedMetadata)
+
+	metadataColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(metadataBytes),
+	}
+	collectionColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(errors.New("collection error")),
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	actualMetadata, err := subject.GetFileMetadata(suite.defaultContext, suite.path)
 
-	expectedMetadata := []files.StoredRegisteredMetaData{metadata}
-	actualMetadata, _ := subject.GetFilesMetadata(suite.defaultContext, suite.defaultCollectionID)
+	logEvent := suite.logInterceptor.GetLogEvent()
 
+	suite.Equal("collection metadata not found", logEvent)
+	suite.EqualError(err, "collection error")
+	suite.Exactly(expectedMetadata, actualMetadata)
+}
+
+func (suite *StoreSuite) TestGetFileMetadataWithCollectionPatching() {
+	metadata := suite.generateMetadata(suite.defaultCollectionID)
+	metadata.State = store.StateUploaded
+	metadataBytes, _ := bson.Marshal(metadata)
+
+	collection := suite.generatePublishedCollectionInfo(suite.defaultCollectionID)
+	collectionBytes, _ := bson.Marshal(collection)
+
+	metadataColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(metadataBytes),
+	}
+	collectionColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(collectionBytes),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	actualMetadata, err := subject.GetFileMetadata(suite.defaultContext, suite.path)
+
+	suite.NoError(err)
+	suite.Equal(collection.State, actualMetadata.State)
+	suite.NotEqual(metadata.State, actualMetadata.State)
+	suite.Equal(collection.PublishedAt, actualMetadata.PublishedAt)
+	suite.NotEqual(metadata.PublishedAt, actualMetadata.PublishedAt)
+	suite.Equal(collection.LastModified, actualMetadata.LastModified)
+	suite.NotEqual(metadata.LastModified, actualMetadata.LastModified)
+}
+
+func (suite *StoreSuite) TestGetFilesMetadataNoPatching() {
+	metadata1 := suite.generateMetadata(suite.defaultCollectionID)
+	metadata1.Path = metadata1.Path + "1"
+	metadata2 := suite.generateMetadata(suite.defaultCollectionID)
+	metadata2.Path = metadata2.Path + "2"
+
+	metadataColl := mock.MongoCollectionMock{
+		FindFunc: CollectionFindReturnsMetadataOnFilter(
+			[]files.StoredRegisteredMetaData{metadata1, metadata2},
+			bson.M{"collection_id": suite.defaultCollectionID},
+		),
+	}
+	collectionColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(nil),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+
+	expectedMetadata := []files.StoredRegisteredMetaData{metadata1, metadata2}
+	actualMetadata, err := subject.GetFilesMetadata(suite.defaultContext, suite.defaultCollectionID)
+
+	suite.NoError(err)
+	suite.Exactly(expectedMetadata, actualMetadata)
+}
+
+func (suite *StoreSuite) TestGetFilesMetadataWithPatching() {
+	metadata1 := suite.generateMetadata(suite.defaultCollectionID)
+	metadata1.Path = metadata1.Path + "1"
+	metadata1.State = store.StateUploaded
+	metadata2 := suite.generateMetadata(suite.defaultCollectionID)
+	metadata2.Path = metadata2.Path + "2"
+	metadata2.State = store.StateUploaded
+
+	collection := suite.generatePublishedCollectionInfo(suite.defaultCollectionID)
+	collectionBytes, _ := bson.Marshal(collection)
+
+	metadataColl := mock.MongoCollectionMock{
+		FindFunc: CollectionFindReturnsMetadataOnFilter(
+			[]files.StoredRegisteredMetaData{metadata1, metadata2},
+			bson.M{"collection_id": suite.defaultCollectionID},
+		),
+	}
+	collectionColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(collectionBytes),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+
+	expectedMetadata := []files.StoredRegisteredMetaData{metadata1, metadata2}
+	expectedMetadata[0].State = store.StatePublished
+	expectedMetadata[0].PublishedAt = collection.PublishedAt
+	expectedMetadata[0].LastModified = collection.LastModified
+	expectedMetadata[1].State = store.StatePublished
+	expectedMetadata[1].PublishedAt = collection.PublishedAt
+	expectedMetadata[1].LastModified = collection.LastModified
+
+	actualMetadata, err := subject.GetFilesMetadata(suite.defaultContext, suite.defaultCollectionID)
+
+	suite.NoError(err)
+	suite.NotEqual(metadata1.State, collection.State)
+	suite.NotEqual(metadata1.PublishedAt, collection.PublishedAt)
+	suite.NotEqual(metadata1.LastModified, collection.LastModified)
+	suite.NotEqual(metadata2.State, collection.State)
+	suite.NotEqual(metadata2.PublishedAt, collection.PublishedAt)
+	suite.NotEqual(metadata2.LastModified, collection.LastModified)
 	suite.Exactly(expectedMetadata, actualMetadata)
 }
 
 func (suite *StoreSuite) TestGetFilesMetadataNoResult() {
-	metadata := suite.generateMetadata(suite.defaultCollectionID)
-	metadataBytes, _ := bson.Marshal(metadata)
-
-	collection := mock.MongoCollectionMock{
-		FindFunc: CollectionFindSetsResultAndReturns1IfCollectionIDMatchesFilter(metadataBytes),
+	metadataColl := mock.MongoCollectionMock{
+		FindFunc: CollectionFindReturnsMetadataOnFilter(
+			[]files.StoredRegisteredMetaData{},
+			bson.M{"collection_id": "INVALID_COLLECTION_ID"},
+		),
+	}
+	collectionColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(nil),
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	expectedMetadata := make([]files.StoredRegisteredMetaData, 0)
-	actualMetadata, _ := subject.GetFilesMetadata(suite.defaultContext, "INVALID_COLLECTION_ID")
+	actualMetadata, err := subject.GetFilesMetadata(suite.defaultContext, "INVALID_COLLECTION_ID")
 
+	suite.NoError(err)
 	suite.Exactly(expectedMetadata, actualMetadata)
+}
+
+func (suite *StoreSuite) TestGetFilesMetadataFindError() {
+	metadataColl := mock.MongoCollectionMock{
+		FindFunc: CollectionFindReturnsValueAndError(0, errors.New("find error")),
+	}
+	collectionColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(nil),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+
+	actualMetadata, err := subject.GetFilesMetadata(suite.defaultContext, suite.defaultCollectionID)
+
+	suite.EqualError(err, "find error")
+	suite.Nil(actualMetadata)
+}
+
+func (suite *StoreSuite) TestGetFilesMetadataCollectionError() {
+	metadataColl := mock.MongoCollectionMock{
+		FindFunc: CollectionFindReturnsMetadataOnFilter(
+			[]files.StoredRegisteredMetaData{},
+			bson.M{"collection_id": suite.defaultCollectionID},
+		),
+	}
+	collectionColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(errors.New("collection error")),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+
+	actualMetadata, err := subject.GetFilesMetadata(suite.defaultContext, suite.defaultCollectionID)
+
+	suite.EqualError(err, "collection error")
+	suite.Nil(actualMetadata)
+}
+
+func (suite *StoreSuite) TestPatchMetadataNilMetadata() {
+	subject := store.NewStore(nil, nil, nil, suite.defaultClock, nil, nil)
+
+	var metadata *files.StoredRegisteredMetaData
+	collection := &files.StoredCollection{}
+
+	subject.PatchMetadataWithCollectionInfo(metadata, collection)
+	suite.Nil(metadata)
+}
+
+func (suite *StoreSuite) TestPatchMetadataNilCollection() {
+	subject := store.NewStore(nil, nil, nil, suite.defaultClock, nil, nil)
+
+	collectionID := "coll1"
+	metadata := files.StoredRegisteredMetaData{
+		Path:         "path1",
+		State:        store.StateUploaded,
+		CollectionID: &collectionID,
+	}
+	metadataExpected := metadata
+
+	subject.PatchMetadataWithCollectionInfo(&metadata, nil)
+	suite.Exactly(metadataExpected, metadata)
+}
+
+func (suite *StoreSuite) TestPatchMetadataNilCollectionID() {
+	subject := store.NewStore(nil, nil, nil, suite.defaultClock, nil, nil)
+
+	metadata := files.StoredRegisteredMetaData{
+		Path:  "path1",
+		State: store.StateUploaded,
+	}
+	collection := &files.StoredCollection{
+		ID:    "coll1",
+		State: store.StatePublished,
+	}
+
+	metadataExpected := metadata
+
+	subject.PatchMetadataWithCollectionInfo(&metadata, collection)
+	suite.Exactly(metadataExpected, metadata)
+}
+
+func (suite *StoreSuite) TestPatchMetadataCollectionIDMismatch() {
+	subject := store.NewStore(nil, nil, nil, suite.defaultClock, nil, nil)
+
+	collectionID := "coll1"
+	metadata := files.StoredRegisteredMetaData{
+		Path:         "path1",
+		State:        store.StateUploaded,
+		CollectionID: &collectionID,
+	}
+	collection := &files.StoredCollection{
+		ID:    "a-different-collection-id",
+		State: store.StatePublished,
+	}
+
+	metadataExpected := metadata
+
+	subject.PatchMetadataWithCollectionInfo(&metadata, collection)
+	suite.Exactly(metadataExpected, metadata)
+}
+
+func (suite *StoreSuite) TestPatchMetadataBadState() {
+	subject := store.NewStore(nil, nil, nil, suite.defaultClock, nil, nil)
+
+	collectionID := "coll1"
+	metadata := files.StoredRegisteredMetaData{
+		Path:         "path1",
+		State:        store.StateDecrypted,
+		CollectionID: &collectionID,
+	}
+	collection := &files.StoredCollection{
+		ID:    collectionID,
+		State: store.StatePublished,
+	}
+
+	metadataExpected := metadata
+
+	subject.PatchMetadataWithCollectionInfo(&metadata, collection)
+	suite.Exactly(metadataExpected, metadata)
+}
+
+func (suite *StoreSuite) TestPatchMetadataBadCollectionState() {
+	subject := store.NewStore(nil, nil, nil, suite.defaultClock, nil, nil)
+
+	collectionID := "coll1"
+	metadata := files.StoredRegisteredMetaData{
+		Path:         "path1",
+		State:        store.StateUploaded,
+		CollectionID: &collectionID,
+	}
+	collection := &files.StoredCollection{
+		ID: collectionID,
+	}
+
+	metadataExpected := metadata
+
+	subject.PatchMetadataWithCollectionInfo(&metadata, collection)
+	suite.Exactly(metadataExpected, metadata)
+}
+
+func (suite *StoreSuite) TestPatchMetadataSuccess() {
+	subject := store.NewStore(nil, nil, nil, suite.defaultClock, nil, nil)
+
+	collectionID := "coll1"
+	publishedAt := suite.generateTestTime(1)
+	lastModified := suite.generateTestTime(2)
+	metadata := files.StoredRegisteredMetaData{
+		Path:         "path1",
+		State:        store.StateUploaded,
+		CollectionID: &collectionID,
+	}
+	collection := &files.StoredCollection{
+		ID:           collectionID,
+		State:        store.StatePublished,
+		PublishedAt:  &publishedAt,
+		LastModified: lastModified,
+	}
+
+	metadataExpected := files.StoredRegisteredMetaData{
+		Path:         "path1",
+		State:        store.StatePublished,
+		CollectionID: &collectionID,
+		PublishedAt:  &publishedAt,
+		LastModified: lastModified,
+	}
+
+	subject.PatchMetadataWithCollectionInfo(&metadata, collection)
+	suite.Exactly(metadataExpected, metadata)
 }

--- a/store/state_changes_test.go
+++ b/store/state_changes_test.go
@@ -30,7 +30,7 @@ func (suite *StoreSuite) TestRegisterFileUploadWhenCollectionAlreadyPublished() 
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&alwaysFindsExistingCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&alwaysFindsExistingCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.RegisterFileUpload(suite.defaultContext, metadata)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -54,7 +54,7 @@ func (suite *StoreSuite) TestRegisterFileUploadWhenFilePathAlreadyExists() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&alwaysFindsExistingCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&alwaysFindsExistingCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.RegisterFileUpload(suite.defaultContext, metadata)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -86,7 +86,7 @@ func (suite *StoreSuite) TestRegisterFileUploadWhenFileDoesNotAlreadyExist() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionCountReturnsZero, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionCountReturnsZero, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.RegisterFileUpload(suite.defaultContext, metadata)
 
 	suite.NoError(err)
@@ -107,7 +107,7 @@ func (suite *StoreSuite) TestRegisterFileUploadInsertReturnsError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionCountReturnsZero, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionCountReturnsZero, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.RegisterFileUpload(suite.defaultContext, metadata)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -131,7 +131,7 @@ func (suite *StoreSuite) TestRegisterFileUploadInsertSucceeds() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionCountReturnsZero, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionCountReturnsZero, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.RegisterFileUpload(suite.defaultContext, metadata)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -165,7 +165,7 @@ func (suite *StoreSuite) TestMarkUploadCompleteFailsWhenNotInCreatedState() {
 		}
 
 		cfg, _ := config.Get()
-		subject := store.NewStore(&collectionWithUploadedFile, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+		subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 		err := subject.MarkUploadComplete(suite.defaultContext, suite.etagReference(metadata))
 
 		logEvent := suite.logInterceptor.GetLogEvent()
@@ -189,7 +189,7 @@ func (suite *StoreSuite) TestMarkUploadCompleteFailsWhenFileNotExists() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.MarkUploadComplete(suite.defaultContext, suite.etagReference(metadata))
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -212,7 +212,7 @@ func (suite *StoreSuite) TestMarkUploadCompleteFailsWhenUpdateReturnsError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.MarkUploadComplete(suite.defaultContext, suite.etagReference(metadata))
 
 	suite.Error(err)
@@ -231,7 +231,7 @@ func (suite *StoreSuite) TestMarkUploadCompleteSucceeds() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.MarkUploadComplete(suite.defaultContext, suite.etagReference(metadata))
 
 	suite.NoError(err)
@@ -262,7 +262,7 @@ func (suite *StoreSuite) TestMarkFileDecryptedFailsWhenNotInCreatedState() {
 		}
 
 		cfg, _ := config.Get()
-		subject := store.NewStore(&collectionWithUploadedFile, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+		subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 		err := subject.MarkFileDecrypted(suite.defaultContext, suite.etagReference(metadata))
 
 		logEvent := suite.logInterceptor.GetLogEvent()
@@ -286,7 +286,7 @@ func (suite *StoreSuite) TestMarkFileDecryptedFailsWhenFileNotExists() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.MarkFileDecrypted(suite.defaultContext, suite.etagReference(metadata))
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -315,7 +315,7 @@ func (suite *StoreSuite) TestMarkFileDecryptedFailsWhenUpdateReturnsError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &suite.defaultKafkaProducer, suite.defaultClock, s3Client, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, s3Client, cfg)
 	err := subject.MarkFileDecrypted(suite.defaultContext, suite.etagReference(metadata))
 
 	suite.Error(err)
@@ -338,7 +338,7 @@ func (suite *StoreSuite) TestMarkFileDecryptedEtagMismatch() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &suite.defaultKafkaProducer, suite.defaultClock, s3Client, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, s3Client, cfg)
 	err := subject.MarkFileDecrypted(suite.defaultContext, suite.etagReference(metadata))
 
 	suite.ErrorIs(err, store.ErrEtagMismatchWhilePublishing, "the actual err was %v", err)
@@ -348,7 +348,7 @@ func (suite *StoreSuite) TestMarkFileDecryptedSucceeds() {
 	metadata := suite.generateMetadata(suite.defaultCollectionID)
 
 	metadata.State = store.StatePublished
-	metadataBytes, _ := bson.Marshal(metadata)	
+	metadataBytes, _ := bson.Marshal(metadata)
 
 	collectionWithUploadedFile := mock.MongoCollectionMock{
 		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(metadataBytes),
@@ -360,7 +360,7 @@ func (suite *StoreSuite) TestMarkFileDecryptedSucceeds() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &suite.defaultKafkaProducer, suite.defaultClock, s3Client, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, s3Client, cfg)
 	err := subject.MarkFileDecrypted(suite.defaultContext, suite.etagReference(metadata))
 
 	suite.NoError(err)
@@ -375,7 +375,7 @@ func (suite *StoreSuite) TestMarkFilePublishedFindReturnsErrNoDocumentFound() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.MarkFilePublished(suite.defaultContext, suite.path)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -396,7 +396,7 @@ func (suite *StoreSuite) TestMarkFilePublishedFindReturnsUnspecifiedError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.MarkFilePublished(suite.defaultContext, suite.path)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -419,7 +419,7 @@ func (suite *StoreSuite) TestMarkFilePublishedCollectionIDNil() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.MarkFilePublished(suite.defaultContext, suite.path)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -449,7 +449,7 @@ func (suite *StoreSuite) TestMarkFilePublishedStateUploaded() {
 		}
 
 		cfg, _ := config.Get()
-		subject := store.NewStore(&collectionWithUploadedFile, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+		subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 		err := subject.MarkFilePublished(suite.defaultContext, suite.path)
 
 		logEvent := suite.logInterceptor.GetLogEvent()
@@ -473,7 +473,7 @@ func (suite *StoreSuite) TestMarkFilePublishedUpdateReturnsError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.MarkFilePublished(suite.defaultContext, suite.path)
 
@@ -497,7 +497,7 @@ func (suite *StoreSuite) TestMarkFilePublishedUpdateKafkaReturnsError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &kafkaMock, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, &kafkaMock, suite.defaultClock, nil, cfg)
 
 	err := subject.MarkFilePublished(suite.defaultContext, suite.path)
 
@@ -521,7 +521,7 @@ func (suite *StoreSuite) TestMarkFilePublishedUpdateKafkaDoesNotReturnError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &kafkaMock, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, &kafkaMock, suite.defaultClock, nil, cfg)
 
 	err := subject.MarkFilePublished(suite.defaultContext, suite.path)
 

--- a/store/store.go
+++ b/store/store.go
@@ -9,13 +9,14 @@ import (
 )
 
 type Store struct {
-	mongoCollection mongo.MongoCollection
-	kafka           kafka.IProducer
-	clock           clock.Clock
-	s3client        aws.S3Clienter
-	cfg             *config.Config
+	metadataCollection    mongo.MongoCollection
+	collectionsCollection mongo.MongoCollection
+	kafka                 kafka.IProducer
+	clock                 clock.Clock
+	s3client              aws.S3Clienter
+	cfg                   *config.Config
 }
 
-func NewStore(collection mongo.MongoCollection, kafkaProducer kafka.IProducer, clk clock.Clock, c aws.S3Clienter, cfg *config.Config) *Store {
-	return &Store{collection, kafkaProducer, clk, c, cfg}
+func NewStore(metadataCollection mongo.MongoCollection, collectionsCollection mongo.MongoCollection, kafkaProducer kafka.IProducer, clk clock.Clock, c aws.S3Clienter, cfg *config.Config) *Store {
+	return &Store{metadataCollection, collectionsCollection, kafkaProducer, clk, c, cfg}
 }


### PR DESCRIPTION
### What

For the optimisation purposes, store the Florence collection publishing information in a separate DB collection.
This will make the collection publishing instantaneous by removing a need to update the publish state of all the files
in the collection, which takes a very long time for large collections.

### How to review

Eyeball

### Who can review

Anyone
