### PR TITLE
dont fail publish if empty collection

### DIFF
--- a/api/collection_published.go
+++ b/api/collection_published.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/ONSdigital/dp-files-api/store"
 	"github.com/gorilla/mux"
 )
 
@@ -13,7 +14,7 @@ func HandleMarkCollectionPublished(markCollectionPublished MarkCollectionPublish
 	return func(w http.ResponseWriter, req *http.Request) {
 		collectionID := mux.Vars(req)["collectionID"]
 
-		if err := markCollectionPublished(req.Context(), collectionID); err != nil {
+		if err := markCollectionPublished(req.Context(), collectionID); err != nil && err != store.ErrNoFilesInCollection {
 			handleError(w, err)
 			return
 		}

--- a/api/collection_published_test.go
+++ b/api/collection_published_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/ONSdigital/dp-files-api/api"
+	"github.com/ONSdigital/dp-files-api/store"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,4 +27,17 @@ func TestPublishHandlerHandlesUnexpectedPublishingError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	response, _ := ioutil.ReadAll(rec.Body)
 	assert.Contains(t, string(response), "InternalError")
+}
+
+func TestPublishHandlerDontReturnErrorIfCollectionEmpty(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/files/ignore.txt", strings.NewReader(`{"collection_id": "asdfghjkl"}`))
+
+	h := api.HandleMarkCollectionPublished(func(ctx context.Context, collectionID string) error {
+		return store.ErrNoFilesInCollection
+	})
+
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusCreated, rec.Code)
 }


### PR DESCRIPTION
### What

Dont fail the publish of a collection if its empty/non-existent in the files DB (else fails the zebedee publish workflow)