### PR TITLE
Feature/add record to bundles collection

### DIFF
--- a/api/register_file.go
+++ b/api/register_file.go
@@ -17,6 +17,7 @@ type RegisterMetadata struct {
 	Path          string  `json:"path" validate:"required,aws-upload-key"`
 	IsPublishable *bool   `json:"is_publishable,omitempty" validate:"required"`
 	CollectionID  *string `json:"collection_id,omitempty"`
+	BundleID      *string `json:"bundle_id,omitempty"`
 	Title         string  `json:"title"`
 	SizeInBytes   uint64  `json:"size_in_bytes" validate:"gt=0"`
 	Type          string  `json:"type"`
@@ -68,6 +69,7 @@ func generateStoredRegisterMetaData(m RegisterMetadata) files.StoredRegisteredMe
 		Path:          m.Path,
 		IsPublishable: *m.IsPublishable,
 		CollectionID:  m.CollectionID,
+		BundleID:      m.BundleID,
 		Title:         m.Title,
 		SizeInBytes:   m.SizeInBytes,
 		Type:          m.Type,

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,7 @@ var cfg *Config
 const (
 	MetadataCollection    = "MetadataCollection"
 	CollectionsCollection = "CollectionsCollection"
+	BundlesCollection     = "BundlesCollection"
 )
 
 // Get returns the default config with any modifications through environment
@@ -75,6 +76,7 @@ func Get() (*Config, error) {
 			Collections: map[string]string{
 				MetadataCollection:    "metadata",
 				CollectionsCollection: "collections",
+				BundlesCollection:     "bundles",
 			},
 			IsStrongReadConcernEnabled:    false,
 			IsWriteConcernMajorityEnabled: true,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,7 +34,7 @@ func TestConfig(t *testing.T) {
 				So(testCfg.MinBatchSize, ShouldEqual, 20)
 				So(testCfg.MongoConfig.ClusterEndpoint, ShouldEqual, "localhost:27017")
 				So(testCfg.MongoConfig.Database, ShouldEqual, "files")
-				So(testCfg.MongoConfig.Collections, ShouldResemble, map[string]string{MetadataCollection: "metadata", CollectionsCollection: "collections"})
+				So(testCfg.MongoConfig.Collections, ShouldResemble, map[string]string{MetadataCollection: "metadata", CollectionsCollection: "collections", BundlesCollection: "bundles"})
 				So(testCfg.MongoConfig.IsStrongReadConcernEnabled, ShouldEqual, false)
 				So(testCfg.MongoConfig.IsWriteConcernMajorityEnabled, ShouldEqual, true)
 				So(testCfg.MongoConfig.ConnectTimeout, ShouldEqual, 5*time.Second)

--- a/features/optional_collection_or_bundle_id.feature
+++ b/features/optional_collection_or_bundle_id.feature
@@ -1,5 +1,5 @@
-Feature: Optional Collection ID
-  Scenario: The one where the collection ID is not sent with the file meta data
+Feature: Optional Collection or Bundle ID
+  Scenario: The one where neither the Collection or Bundle ID is sent with the file meta data
     Given I am an authorised user
     When the file upload is registered with payload:
         """

--- a/features/register_files.feature
+++ b/features/register_files.feature
@@ -1,6 +1,6 @@
 Feature: Register new file upload
 
-  Scenario: Register that an upload has started
+  Scenario: Register that a collection upload has started
     Given I am an authorised user
     When the file upload is registered with payload:
         """
@@ -20,6 +20,35 @@ Feature: Register new file upload
       | Path          | images/meme.jpg                                                          |
       | IsPublishable | true                                                                      |
       | CollectionID  | 1234-asdfg-54321-qwerty                                                   |
+      | Title         | The latest Meme                                                           |
+      | SizeInBytes   | 14794                                                                     |
+      | Type          | image/jpeg                                                                |
+      | Licence       | OGL v3                                                                    |
+      | LicenceURL    | http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+      | CreatedAt     | 2021-10-19T09:30:30Z                                                      |
+      | LastModified  | 2021-10-19T09:30:30Z                                                      |
+      | State         | CREATED                                                                   |
+  
+  Scenario: Register that a bundle upload has started
+    Given I am an authorised user
+    When the file upload is registered with payload:
+        """
+        {
+          "path": "images/meme.jpg",
+          "is_publishable": true,
+          "bundle_id": "1234-asdfg-54321-qwerty",
+          "title": "The latest Meme",
+          "size_in_bytes": 14794,
+          "type": "image/jpeg",
+          "licence": "OGL v3",
+          "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+        }
+        """
+    Then the HTTP status code should be "201"
+    And the following document entry should be created:
+      | Path          | images/meme.jpg                                                           |
+      | IsPublishable | true                                                                      |
+      | BundleID      | 1234-asdfg-54321-qwerty                                                   |
       | Title         | The latest Meme                                                           |
       | SizeInBytes   | 14794                                                                     |
       | Type          | image/jpeg                                                                |

--- a/features/steps/files_api_component.go
+++ b/features/steps/files_api_component.go
@@ -105,6 +105,24 @@ func (c *FilesAPIComponent) Reset() {
 		log.Error(ctx, "failed to create index on collections collection", err)
 		panic(err)
 	}
+	if err := c.mongoClient.Database("files").Collection("bundles").Drop(ctx); err != nil {
+		log.Error(ctx, "failed to drop bundles collection", err)
+		panic(err)
+	}
+	if err := c.mongoClient.Database("files").CreateCollection(ctx, "bundles"); err != nil {
+		log.Error(ctx, "failed to create bundles collection", err)
+		panic(err)
+	}
+	if _, err := c.mongoClient.Database("files").Collection("bundles").Indexes().CreateOne(
+		ctx,
+		mongo.IndexModel{
+			Keys:    bson.D{{Key: "id", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+	); err != nil {
+		log.Error(ctx, "failed to create index on bundles collection", err)
+		panic(err)
+	}
 	c.isPublishing = true
 }
 

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -67,6 +67,7 @@ type ExpectedMetaData struct {
 	Path          string
 	IsPublishable string
 	CollectionID  string
+	BundleID      string
 	Title         string
 	SizeInBytes   string
 	Type          string
@@ -113,8 +114,6 @@ func (c *FilesAPIComponent) theFollowingDocumentShouldBeCreated(table *godog.Tab
 	res := c.mongoClient.Database("files").Collection("metadata").FindOne(ctx, bson.M{"path": expectedMetaData.Path})
 	assert.NoError(c.APIFeature, res.Decode(&metaData))
 
-	fmt.Println("EXPECTD METADATA", expectedMetaData.CollectionID)
-
 	isPublishable, _ := strconv.ParseBool(expectedMetaData.IsPublishable)
 	sizeInBytes, _ := strconv.ParseUint(expectedMetaData.SizeInBytes, 10, 64)
 	assert.Equal(c.APIFeature, isPublishable, metaData.IsPublishable)
@@ -123,6 +122,12 @@ func (c *FilesAPIComponent) theFollowingDocumentShouldBeCreated(table *godog.Tab
 	} else {
 		assert.Equal(c.APIFeature, expectedMetaData.CollectionID, *metaData.CollectionID)
 	}
+	if expectedMetaData.BundleID == "" {
+		assert.Nil(c.APIFeature, metaData.BundleID)
+	} else {
+		assert.Equal(c.APIFeature, expectedMetaData.BundleID, *metaData.BundleID)
+	}
+
 	assert.Equal(c.APIFeature, expectedMetaData.Title, metaData.Title)
 	assert.Equal(c.APIFeature, sizeInBytes, metaData.SizeInBytes)
 	assert.Equal(c.APIFeature, expectedMetaData.Type, metaData.Type)
@@ -165,6 +170,7 @@ func (c *FilesAPIComponent) theFileUploadHasBeenPublishedWith(path string, table
 		Path:              path,
 		IsPublishable:     isPublishable,
 		CollectionID:      &data.CollectionID,
+		BundleID:          &data.BundleID,
 		Title:             data.Title,
 		SizeInBytes:       sizeInBytes,
 		Type:              data.Type,
@@ -217,6 +223,10 @@ func (c *FilesAPIComponent) theFileUploadHasBeenCompletedWith(path string, table
 		m.CollectionID = &data.CollectionID
 	}
 
+	if data.BundleID != "" {
+		m.BundleID = &data.BundleID
+	}
+
 	_, err = c.mongoClient.Database("files").Collection("metadata").InsertOne(context.Background(), &m)
 	assert.NoError(c.APIFeature, err)
 
@@ -251,6 +261,10 @@ func (c *FilesAPIComponent) theFileUploadHasBeenRegisteredWith(path string, tabl
 
 	if data.CollectionID != "" {
 		m.CollectionID = &data.CollectionID
+	}
+
+	if data.BundleID != "" {
+		m.BundleID = &data.BundleID
 	}
 
 	_, err = c.mongoClient.Database("files").Collection("metadata").InsertOne(context.Background(), &m)

--- a/files/metadata.go
+++ b/files/metadata.go
@@ -8,6 +8,7 @@ type StoredRegisteredMetaData struct {
 	Path              string     `bson:"path" json:"path"`
 	IsPublishable     bool       `bson:"is_publishable" json:"is_publishable"`
 	CollectionID      *string    `bson:"collection_id,omitempty" json:"collection_id,omitempty"`
+	BundleID          *string    `bson:"bundle_id,omitempty" json:"bundle_id,omitempty"`
 	Title             string     `bson:"title" json:"title"`
 	SizeInBytes       uint64     `bson:"size_in_bytes" json:"size_in_bytes"`
 	Type              string     `bson:"type" json:"type"`

--- a/files/metadata.go
+++ b/files/metadata.go
@@ -30,6 +30,12 @@ type StoredCollection struct {
 	PublishedAt  *time.Time `bson:"published_at,omitempty" json:"-"`
 }
 
+type StoredBundle struct {
+	ID           string    `bson:"id" json:"id"`
+	State        string    `bson:"state" json:"state"`
+	LastModified time.Time `bson:"last_modified" json:"-"`
+}
+
 type FileEtagChange struct {
 	Path string
 	Etag string

--- a/service/service.go
+++ b/service/service.go
@@ -59,6 +59,7 @@ func Run(ctx context.Context, serviceList ServiceContainer, svcErrors chan error
 	store := store.NewStore(
 		mongoClient.Collection(config.MetadataCollection),
 		mongoClient.Collection(config.CollectionsCollection),
+		mongoClient.Collection(config.BundlesCollection),
 		kafkaProducer,
 		serviceList.GetClock(),
 		s3Client,

--- a/store/bundle_operations.go
+++ b/store/bundle_operations.go
@@ -1,0 +1,102 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ONSdigital/dp-files-api/config"
+	"github.com/ONSdigital/dp-files-api/files"
+	mongodriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
+	"github.com/ONSdigital/log.go/v2/log"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func (store *Store) IsBundlePublished(ctx context.Context, bundleID string) (bool, error) {
+	bundle, err := store.GetBundlePublishedMetadata(ctx, bundleID)
+	if err != nil {
+		// If there's no record of bundle being published in bundles DB, fall back
+		// to the older method that checks the file statuses (if all files in the bundle are marked
+		// as published, we consider the bundle published).
+		if errors.Is(err, ErrBundleMetadataNotRegistered) {
+			return store.AreAllBundleFilesPublished(ctx, bundleID)
+		}
+		// we've hit an unexpected error
+		return false, fmt.Errorf("bundle published check: %w", err)
+	}
+	if bundle.State == StatePublished {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (store *Store) GetBundlePublishedMetadata(ctx context.Context, id string) (files.StoredCollection, error) {
+	bundle := files.StoredCollection{}
+	err := store.bundlesCollection.FindOne(ctx, bson.M{fieldID: id}, &bundle)
+	if err != nil {
+		if errors.Is(err, mongodriver.ErrNoDocumentFound) {
+			return files.StoredCollection{}, ErrBundleMetadataNotRegistered
+		}
+		log.Error(ctx, "bundle metadata fetch error", err, log.Data{"id": id})
+		return files.StoredCollection{}, err
+	}
+	return bundle, err
+}
+
+func (store *Store) AreAllBundleFilesPublished(ctx context.Context, bundleID string) (bool, error) {
+	empty, err := store.IsBundleEmpty(ctx, bundleID)
+	if err != nil {
+		return false, fmt.Errorf("AreAllBundleFilesPublished empty bundle check: %w", err)
+	}
+	if empty {
+		return false, nil
+	}
+
+	metadata := files.StoredRegisteredMetaData{}
+	err = store.metadataCollection.FindOne(ctx, bson.M{"$and": []bson.M{
+		{fieldBundleID: bundleID},
+		{fieldState: bson.M{"$ne": StatePublished}},
+		{fieldState: bson.M{"$ne": StateMoved}},
+	}}, &metadata)
+	if err != nil {
+		if errors.Is(err, mongodriver.ErrNoDocumentFound) {
+			return true, nil
+		}
+		return false, fmt.Errorf("AreAllBundleFilesPublished check: %w", err)
+	}
+	return false, nil
+}
+
+func (store *Store) IsBundleEmpty(ctx context.Context, bundleID string) (bool, error) {
+	metadata := files.StoredRegisteredMetaData{}
+
+	err := store.metadataCollection.FindOne(ctx, bson.M{fieldBundleID: bundleID}, &metadata)
+	if err != nil {
+		if errors.Is(err, mongodriver.ErrNoDocumentFound) {
+			return true, nil
+		}
+		return true, err
+	}
+
+	return false, nil
+}
+
+func (store *Store) registerBundle(ctx context.Context, bundleID string) error {
+	logdata := log.Data{"bundle_id": bundleID}
+	now := store.clock.GetCurrentTime()
+	bundle := files.StoredCollection{
+		ID:           bundleID,
+		State:        StateCreated,
+		LastModified: now,
+	}
+	if _, err := store.bundlesCollection.Insert(ctx, bundle); err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			log.Info(ctx, "bundle already registered", logdata)
+			return nil
+		}
+		log.Error(ctx, "failed to insert bundle record", err, log.Data{"bundle": config.BundlesCollection, "record": bundle})
+		return err
+	}
+	return nil
+}

--- a/store/bundle_operations.go
+++ b/store/bundle_operations.go
@@ -31,15 +31,15 @@ func (store *Store) IsBundlePublished(ctx context.Context, bundleID string) (boo
 	return false, nil
 }
 
-func (store *Store) GetBundlePublishedMetadata(ctx context.Context, id string) (files.StoredCollection, error) {
-	bundle := files.StoredCollection{}
+func (store *Store) GetBundlePublishedMetadata(ctx context.Context, id string) (files.StoredBundle, error) {
+	bundle := files.StoredBundle{}
 	err := store.bundlesCollection.FindOne(ctx, bson.M{fieldID: id}, &bundle)
 	if err != nil {
 		if errors.Is(err, mongodriver.ErrNoDocumentFound) {
-			return files.StoredCollection{}, ErrBundleMetadataNotRegistered
+			return files.StoredBundle{}, ErrBundleMetadataNotRegistered
 		}
 		log.Error(ctx, "bundle metadata fetch error", err, log.Data{"id": id})
-		return files.StoredCollection{}, err
+		return files.StoredBundle{}, err
 	}
 	return bundle, err
 }
@@ -85,7 +85,7 @@ func (store *Store) IsBundleEmpty(ctx context.Context, bundleID string) (bool, e
 func (store *Store) registerBundle(ctx context.Context, bundleID string) error {
 	logdata := log.Data{"bundle_id": bundleID}
 	now := store.clock.GetCurrentTime()
-	bundle := files.StoredCollection{
+	bundle := files.StoredBundle{
 		ID:           bundleID,
 		State:        StateCreated,
 		LastModified: now,

--- a/store/bundle_operations_test.go
+++ b/store/bundle_operations_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (suite *StoreSuite) TestGetBundlePublishedMetadataSuccess() {
-	expectedBundle := files.StoredCollection{
+	expectedBundle := files.StoredBundle{
 		ID:    suite.defaultBundleID,
 		State: store.StatePublished,
 	}
@@ -43,7 +43,7 @@ func (suite *StoreSuite) TestGetBundlePublishedMetadataNotFound() {
 
 	suite.Error(err)
 	suite.ErrorIs(err, store.ErrBundleMetadataNotRegistered)
-	suite.Equal(files.StoredCollection{}, actualBundle)
+	suite.Equal(files.StoredBundle{}, actualBundle)
 }
 
 func (suite *StoreSuite) TestGetBundlePublishedMetadataUnexpectedError() {
@@ -60,10 +60,10 @@ func (suite *StoreSuite) TestGetBundlePublishedMetadataUnexpectedError() {
 
 	suite.Error(err)
 	suite.ErrorIs(err, expectedError)
-	suite.Equal(files.StoredCollection{}, actualBundle)
+	suite.Equal(files.StoredBundle{}, actualBundle)
 }
 func (suite *StoreSuite) TestIsBundlePublishedSuccess() {
-	expectedBundle := files.StoredCollection{
+	expectedBundle := files.StoredBundle{
 		ID:    suite.defaultBundleID,
 		State: store.StatePublished,
 	}
@@ -83,7 +83,7 @@ func (suite *StoreSuite) TestIsBundlePublishedSuccess() {
 }
 
 func (suite *StoreSuite) TestIsBundlePublishedNotPublishedState() {
-	expectedBundle := files.StoredCollection{
+	expectedBundle := files.StoredBundle{
 		ID:    suite.defaultBundleID,
 		State: store.StateCreated,
 	}

--- a/store/bundle_operations_test.go
+++ b/store/bundle_operations_test.go
@@ -1,0 +1,199 @@
+package store_test
+
+import (
+	"errors"
+
+	"github.com/ONSdigital/dp-files-api/config"
+	"github.com/ONSdigital/dp-files-api/files"
+	"github.com/ONSdigital/dp-files-api/mongo/mock"
+	"github.com/ONSdigital/dp-files-api/store"
+	mongodriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func (suite *StoreSuite) TestGetBundlePublishedMetadataSuccess() {
+	expectedBundle := files.StoredCollection{
+		ID:    suite.defaultBundleID,
+		State: store.StatePublished,
+	}
+	bundleBytes, _ := bson.Marshal(expectedBundle)
+
+	bundlesCollection := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(bundleBytes),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(nil, nil, &bundlesCollection, nil, suite.defaultClock, nil, cfg)
+
+	actualBundle, err := subject.GetBundlePublishedMetadata(suite.defaultContext, suite.defaultBundleID)
+
+	suite.NoError(err)
+	suite.Exactly(expectedBundle, actualBundle)
+}
+
+func (suite *StoreSuite) TestGetBundlePublishedMetadataNotFound() {
+	bundlesCollection := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(mongodriver.ErrNoDocumentFound),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(nil, nil, &bundlesCollection, nil, suite.defaultClock, nil, cfg)
+
+	actualBundle, err := subject.GetBundlePublishedMetadata(suite.defaultContext, "non-existent-bundle-id")
+
+	suite.Error(err)
+	suite.ErrorIs(err, store.ErrBundleMetadataNotRegistered)
+	suite.Equal(files.StoredCollection{}, actualBundle)
+}
+
+func (suite *StoreSuite) TestGetBundlePublishedMetadataUnexpectedError() {
+	expectedError := errors.New("unexpected error")
+
+	bundlesCollection := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(expectedError),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(nil, nil, &bundlesCollection, nil, suite.defaultClock, nil, cfg)
+
+	actualBundle, err := subject.GetBundlePublishedMetadata(suite.defaultContext, suite.defaultBundleID)
+
+	suite.Error(err)
+	suite.ErrorIs(err, expectedError)
+	suite.Equal(files.StoredCollection{}, actualBundle)
+}
+func (suite *StoreSuite) TestIsBundlePublishedSuccess() {
+	expectedBundle := files.StoredCollection{
+		ID:    suite.defaultBundleID,
+		State: store.StatePublished,
+	}
+	bundleBytes, _ := bson.Marshal(expectedBundle)
+
+	bundlesCollection := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(bundleBytes),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(nil, nil, &bundlesCollection, nil, suite.defaultClock, nil, cfg)
+
+	isPublished, err := subject.IsBundlePublished(suite.defaultContext, suite.defaultBundleID)
+
+	suite.NoError(err)
+	suite.True(isPublished)
+}
+
+func (suite *StoreSuite) TestIsBundlePublishedNotPublishedState() {
+	expectedBundle := files.StoredCollection{
+		ID:    suite.defaultBundleID,
+		State: store.StateCreated,
+	}
+	bundleBytes, _ := bson.Marshal(expectedBundle)
+
+	bundlesCollection := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(bundleBytes),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(nil, nil, &bundlesCollection, nil, suite.defaultClock, nil, cfg)
+
+	isPublished, err := subject.IsBundlePublished(suite.defaultContext, suite.defaultBundleID)
+
+	suite.NoError(err)
+	suite.False(isPublished)
+}
+
+func (suite *StoreSuite) TestIsBundlePublishedFallbackToFileCheckNotPublished() {
+	bundlesCollection := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(store.ErrBundleMetadataNotRegistered),
+	}
+
+	metadata := bson.M{
+		"state": store.StateCreated,
+	}
+	metadataBytes, _ := bson.Marshal(metadata)
+
+	metadataCollection := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(metadataBytes),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(&metadataCollection, nil, &bundlesCollection, nil, suite.defaultClock, nil, cfg)
+
+	isPublished, err := subject.IsBundlePublished(suite.defaultContext, suite.defaultBundleID)
+
+	suite.NoError(err)
+	suite.False(isPublished)
+}
+
+func (suite *StoreSuite) TestIsBundlePublishedUnexpectedError() {
+	expectedError := errors.New("unexpected error")
+
+	bundlesCollection := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(expectedError),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(nil, nil, &bundlesCollection, nil, suite.defaultClock, nil, cfg)
+
+	isPublished, err := subject.IsBundlePublished(suite.defaultContext, suite.defaultBundleID)
+
+	suite.Error(err)
+	suite.ErrorIs(err, expectedError)
+	suite.False(isPublished)
+}
+
+func (suite *StoreSuite) TestAreAllBundleFilesPublishedNotAllFilesPublished() {
+	metadata := files.StoredRegisteredMetaData{
+		BundleID: &suite.defaultBundleID,
+		State:    store.StateCreated,
+	}
+	metadataBytes, _ := bson.Marshal(metadata)
+
+	metadataCollection := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(metadataBytes),
+	}
+
+	bundlesCollection := mock.MongoCollectionMock{}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(&metadataCollection, nil, &bundlesCollection, nil, suite.defaultClock, nil, cfg)
+
+	isPublished, err := subject.AreAllBundleFilesPublished(suite.defaultContext, suite.defaultBundleID)
+
+	suite.NoError(err)
+	suite.False(isPublished)
+}
+
+func (suite *StoreSuite) TestAreAllBundleFilesPublishedEmptyBundle() {
+	bundlesCollection := mock.MongoCollectionMock{}
+	metadataCollection := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(mongodriver.ErrNoDocumentFound),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(&metadataCollection, nil, &bundlesCollection, nil, suite.defaultClock, nil, cfg)
+
+	isPublished, err := subject.AreAllBundleFilesPublished(suite.defaultContext, "empty-bundle-id")
+
+	suite.NoError(err)
+	suite.False(isPublished)
+}
+
+func (suite *StoreSuite) TestAreAllBundleFilesPublishedUnexpectedError() {
+	expectedError := errors.New("unexpected error")
+
+	metadataCollection := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(expectedError),
+	}
+
+	bundlesCollection := mock.MongoCollectionMock{}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(&metadataCollection, nil, &bundlesCollection, nil, suite.defaultClock, nil, cfg)
+
+	isPublished, err := subject.AreAllBundleFilesPublished(suite.defaultContext, suite.defaultBundleID)
+
+	suite.Error(err)
+	suite.ErrorIs(err, expectedError)
+	suite.False(isPublished)
+}

--- a/store/collection_operations.go
+++ b/store/collection_operations.go
@@ -24,7 +24,7 @@ func (store *Store) IsCollectionPublished(ctx context.Context, collectionID stri
 		// to the older method that checks the file statuses (if all files in the collection are marked
 		// as published, we consider the collection published).
 		if errors.Is(err, ErrCollectionMetadataNotRegistered) {
-			return store.AreAllFilesPublished(ctx, collectionID)
+			return store.AreAllCollectionFilesPublished(ctx, collectionID)
 		}
 		// we've hit an unexpected error
 		return false, fmt.Errorf("collection published check: %w", err)
@@ -35,10 +35,10 @@ func (store *Store) IsCollectionPublished(ctx context.Context, collectionID stri
 	return false, nil
 }
 
-func (store *Store) AreAllFilesPublished(ctx context.Context, collectionID string) (bool, error) {
+func (store *Store) AreAllCollectionFilesPublished(ctx context.Context, collectionID string) (bool, error) {
 	empty, err := store.IsCollectionEmpty(ctx, collectionID)
 	if err != nil {
-		return false, fmt.Errorf("AreAllFilesPublished empty collection check: %w", err)
+		return false, fmt.Errorf("AreAllCollectionFilesPublished empty collection check: %w", err)
 	}
 	if empty {
 		return false, nil
@@ -54,7 +54,7 @@ func (store *Store) AreAllFilesPublished(ctx context.Context, collectionID strin
 		if errors.Is(err, mongodriver.ErrNoDocumentFound) {
 			return true, nil
 		}
-		return false, fmt.Errorf("AreAllFilesPublished check: %w", err)
+		return false, fmt.Errorf("AreAllCollectionFilesPublished check: %w", err)
 	}
 	return false, nil
 }

--- a/store/collection_operations_test.go
+++ b/store/collection_operations_test.go
@@ -63,7 +63,7 @@ func (suite *StoreSuite) TestUpdateCollectionIDCollectionIDAlreadySet() {
 	suite.logInterceptor.Start()
 	defer suite.logInterceptor.Stop()
 
-	metadata := suite.generateMetadata(suite.defaultCollectionID)
+	metadata := suite.generateCollectionMetadata(suite.defaultCollectionID)
 	metadataBytes, _ := bson.Marshal(metadata)
 
 	collectionWithUploadedFile := mock.MongoCollectionMock{
@@ -85,7 +85,7 @@ func (suite *StoreSuite) TestUpdateCollectionIDCollectionCheckFail() {
 	suite.logInterceptor.Start()
 	defer suite.logInterceptor.Stop()
 
-	metadata := suite.generateMetadata("")
+	metadata := suite.generateCollectionMetadata("")
 	metadata.State = store.StateUploaded
 	metadata.CollectionID = nil
 	metadataBytes, _ := bson.Marshal(metadata)
@@ -115,7 +115,7 @@ func (suite *StoreSuite) TestUpdateCollectionIDCollectionAlreadyPublished() {
 	suite.logInterceptor.Start()
 	defer suite.logInterceptor.Stop()
 
-	metadata := suite.generateMetadata("")
+	metadata := suite.generateCollectionMetadata("")
 	metadata.State = store.StatePublished
 	metadata.CollectionID = nil
 	metadataBytes, _ := bson.Marshal(metadata)
@@ -142,7 +142,7 @@ func (suite *StoreSuite) TestUpdateCollectionIDCollectionAlreadyPublished() {
 }
 
 func (suite *StoreSuite) TestUpdateCollectionIDUpdateReturnsError() {
-	metadata := suite.generateMetadata("")
+	metadata := suite.generateCollectionMetadata("")
 	metadata.State = store.StateUploaded
 	metadata.CollectionID = nil
 	metadataBytes, _ := bson.Marshal(metadata)
@@ -169,7 +169,7 @@ func (suite *StoreSuite) TestUpdateCollectionIDUpdateReturnsError() {
 }
 
 func (suite *StoreSuite) TestUpdateCollectionIDUpdateSuccess() {
-	metadata := suite.generateMetadata("")
+	metadata := suite.generateCollectionMetadata("")
 	metadata.State = store.StateUploaded
 	metadata.CollectionID = nil
 	metadataBytes, _ := bson.Marshal(metadata)
@@ -398,7 +398,7 @@ func (suite *StoreSuite) TestNotifyCollectionPublishedFindErrored() {
 }
 
 func (suite *StoreSuite) TestNotifyCollectionPublishedPersistenceSuccess() {
-	metadata := suite.generateMetadata(suite.defaultCollectionID)
+	metadata := suite.generateCollectionMetadata(suite.defaultCollectionID)
 	metadataBytes, _ := bson.Marshal(metadata)
 
 	cursor := mock.MongoCursorMock{
@@ -448,7 +448,7 @@ func (suite *StoreSuite) TestBatchingWithLargeNumberOfFiles() {
 	cfg, _ := config.Get()
 	expectedBatchSize := int(math.Ceil(float64(numFiles) / float64(cfg.MaxNumBatches)))
 
-	metadata := suite.generateMetadata(suite.defaultCollectionID)
+	metadata := suite.generateCollectionMetadata(suite.defaultCollectionID)
 	metadataBytes, _ := bson.Marshal(metadata)
 
 	cursor := mock.MongoCursorMock{
@@ -496,7 +496,7 @@ func (suite *StoreSuite) TestBatchingWithLargeNumberOfFiles() {
 }
 
 func (suite *StoreSuite) TestNotifyCollectionPublishedKafkaErrorDoesNotFailOperation() {
-	metadata := suite.generateMetadata(suite.defaultCollectionID)
+	metadata := suite.generateCollectionMetadata(suite.defaultCollectionID)
 	metadataBytes, _ := bson.Marshal(metadata)
 
 	kafkaError := errors.New("an error occurred with Kafka")

--- a/store/collection_operations_test.go
+++ b/store/collection_operations_test.go
@@ -26,7 +26,7 @@ func (suite *StoreSuite) TestUpdateCollectionIDFindReturnsErrNoDocumentFound() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.UpdateCollectionID(suite.defaultContext, suite.path, suite.defaultCollectionID)
 
@@ -48,7 +48,7 @@ func (suite *StoreSuite) TestUpdateCollectionIDFindReturnsUnspecifiedError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.UpdateCollectionID(suite.defaultContext, "", suite.defaultCollectionID)
 
@@ -71,7 +71,7 @@ func (suite *StoreSuite) TestUpdateCollectionIDCollectionIDAlreadySet() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.UpdateCollectionID(suite.defaultContext, suite.path, suite.defaultCollectionID)
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -102,7 +102,7 @@ func (suite *StoreSuite) TestUpdateCollectionIDCollectionCheckFail() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &collCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &collCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.UpdateCollectionID(suite.defaultContext, suite.path, suite.defaultCollectionID)
 
@@ -131,7 +131,7 @@ func (suite *StoreSuite) TestUpdateCollectionIDCollectionAlreadyPublished() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &collCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &collCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.UpdateCollectionID(suite.defaultContext, suite.path, suite.defaultCollectionID)
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -160,7 +160,7 @@ func (suite *StoreSuite) TestUpdateCollectionIDUpdateReturnsError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &emptyCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &emptyCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.UpdateCollectionID(suite.defaultContext, suite.path, suite.defaultCollectionID)
 
@@ -185,7 +185,7 @@ func (suite *StoreSuite) TestUpdateCollectionIDUpdateSuccess() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionContainsOneUploadedFileWithNoCollectionID, &emptyCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionContainsOneUploadedFileWithNoCollectionID, &emptyCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.UpdateCollectionID(suite.defaultContext, suite.path, suite.defaultCollectionID)
 
@@ -203,7 +203,7 @@ func (suite *StoreSuite) TestMarkCollectionPublishedCollectionEmptyCheckReturnsE
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionCountReturnsError, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionCountReturnsError, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.MarkCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -223,7 +223,7 @@ func (suite *StoreSuite) TestMarkCollectionPublishedCollectionEmpty() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionCountReturnsError, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionCountReturnsError, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.MarkCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -246,7 +246,7 @@ func (suite *StoreSuite) TestMarkCollectionPublishedWhenFileExistsInStateOtherTh
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collection, &collCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collection, &collCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.MarkCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -274,7 +274,7 @@ func (suite *StoreSuite) TestMarkCollectionPublishedCollectionUploadedCheckRetur
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionCountReturnsError, &collCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionCountReturnsError, &collCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.MarkCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -309,7 +309,7 @@ func (suite *StoreSuite) TestMarkCollectionPublishedCollectionPublishedCheckRetu
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionCountReturnsError, &collCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionCountReturnsError, &collCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.MarkCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -338,7 +338,7 @@ func (suite *StoreSuite) TestMarkCollectionPublishedPersistenceFailure() {
 		FindOneFunc: CollectionFindOneSucceeds(), // collection is not PUBLISHED
 	}
 	cfg, _ := config.Get()
-	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&metadataColl, &collectionColl, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.MarkCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -368,7 +368,7 @@ func (suite *StoreSuite) TestMarkCollectionPublishedFindCalled() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&metadataColl, &collectionColl, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.MarkCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -388,7 +388,7 @@ func (suite *StoreSuite) TestNotifyCollectionPublishedFindErrored() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collection, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	subject.NotifyCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -430,7 +430,7 @@ func (suite *StoreSuite) TestNotifyCollectionPublishedPersistenceSuccess() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collection, nil, &kafkaMock, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collection, nil, nil, &kafkaMock, suite.defaultClock, nil, cfg)
 
 	subject.NotifyCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -479,7 +479,7 @@ func (suite *StoreSuite) TestBatchingWithLargeNumberOfFiles() {
 		},
 	}
 
-	subject := store.NewStore(&collection, nil, &kafkaMock, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collection, nil, nil, &kafkaMock, suite.defaultClock, nil, cfg)
 
 	subject.NotifyCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -520,7 +520,7 @@ func (suite *StoreSuite) TestNotifyCollectionPublishedKafkaErrorDoesNotFailOpera
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collection, nil, &kafkaMock, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collection, nil, nil, &kafkaMock, suite.defaultClock, nil, cfg)
 
 	subject.NotifyCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -551,7 +551,7 @@ func (suite *StoreSuite) TestNotifyCollectionPublishedDecodeErrorDoesNotFailOper
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collection, nil, &kafkaMock, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collection, nil, nil, &kafkaMock, suite.defaultClock, nil, cfg)
 
 	subject.NotifyCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -568,7 +568,7 @@ func (suite *StoreSuite) TestIsCollectionPublishedNoMetadata() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&emptyCollection, &emptyCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&emptyCollection, &emptyCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	published, err := subject.IsCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -583,7 +583,7 @@ func (suite *StoreSuite) TestIsCollectionPublishedMetadataError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(nil, &erroringCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(nil, &erroringCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	published, err := subject.IsCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -609,7 +609,7 @@ func (suite *StoreSuite) TestIsCollectionPublishedMetadataPublished() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &collCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &collCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	published, err := subject.IsCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -631,7 +631,7 @@ func (suite *StoreSuite) TestIsCollectionPublishedNoCollectionAllFilesNotPublish
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &collCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &collCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	published, err := subject.IsCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -654,7 +654,7 @@ func (suite *StoreSuite) TestIsCollectionPublishedCollectionError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &collCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &collCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	published, err := subject.IsCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -681,7 +681,7 @@ func (suite *StoreSuite) TestIsCollectionPublishedCollectionPublished() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &collCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &collCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	published, err := subject.IsCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 
@@ -707,7 +707,7 @@ func (suite *StoreSuite) TestIsCollectionPublishedCollectionNotPublished() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &collCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &collCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	published, err := subject.IsCollectionPublished(suite.defaultContext, suite.defaultCollectionID)
 

--- a/store/errors.go
+++ b/store/errors.go
@@ -13,6 +13,8 @@ var (
 	ErrCollectionIDAlreadySet          = errors.New("collection ID already set")
 	ErrCollectionIDNotSet              = errors.New("collection ID not set")
 	ErrCollectionAlreadyPublished      = errors.New("collection with the given id is already published")
+	ErrBundleAlreadyPublished          = errors.New("bundle with the given id is already published")
 	ErrCollectionMetadataNotRegistered = errors.New("collection metadata not registered")
+	ErrBundleMetadataNotRegistered     = errors.New("bundle metadata not registered")
 	ErrEtagMismatchWhilePublishing     = errors.New("etag mismatch")
 )

--- a/store/fields.go
+++ b/store/fields.go
@@ -4,6 +4,7 @@ const (
 	fieldID                = "id"
 	fieldPath              = "path"
 	fieldCollectionID      = "collection_id"
+	fieldBundleID          = "bundle_id"
 	fieldEtag              = "etag"
 	fieldState             = "state"
 	fieldLastModified      = "last_modified"

--- a/store/integration_test.go
+++ b/store/integration_test.go
@@ -46,7 +46,7 @@ func (s *StoreIntegrationTest) SetupTest() {
 	client.Database("files").Collection("metadata").Drop(s.ctx)
 
 	cfg, _ := config.Get()
-	s.store = store.NewStore(s.mc.Collection(config.MetadataCollection), s.mc.Collection(config.CollectionsCollection), &kafkatest.IProducerMock{}, steps.TestClock{}, nil, cfg)
+	s.store = store.NewStore(s.mc.Collection(config.MetadataCollection), s.mc.Collection(config.CollectionsCollection), s.mc.Collection(config.BundlesCollection), &kafkatest.IProducerMock{}, steps.TestClock{}, nil, cfg)
 }
 
 func TestStoreIntegration(t *testing.T) {

--- a/store/metadata_retrieval_test.go
+++ b/store/metadata_retrieval_test.go
@@ -42,7 +42,7 @@ func (suite *StoreSuite) TestGetFileMetadataOtherError() {
 }
 
 func (suite *StoreSuite) TestGetFileMetadataNoCollectionPatching() {
-	expectedMetadata := suite.generateMetadata(suite.defaultCollectionID)
+	expectedMetadata := suite.generateCollectionMetadata(suite.defaultCollectionID)
 
 	metadataBytes, _ := bson.Marshal(expectedMetadata)
 
@@ -61,7 +61,7 @@ func (suite *StoreSuite) TestGetFileMetadataCollectionError() {
 	suite.logInterceptor.Start()
 	defer suite.logInterceptor.Stop()
 
-	expectedMetadata := suite.generateMetadata(suite.defaultCollectionID)
+	expectedMetadata := suite.generateCollectionMetadata(suite.defaultCollectionID)
 	expectedMetadata.State = store.StateUploaded
 	metadataBytes, _ := bson.Marshal(expectedMetadata)
 
@@ -84,7 +84,7 @@ func (suite *StoreSuite) TestGetFileMetadataCollectionError() {
 }
 
 func (suite *StoreSuite) TestGetFileMetadataWithCollectionPatching() {
-	metadata := suite.generateMetadata(suite.defaultCollectionID)
+	metadata := suite.generateCollectionMetadata(suite.defaultCollectionID)
 	metadata.State = store.StateUploaded
 	metadataBytes, _ := bson.Marshal(metadata)
 
@@ -112,9 +112,9 @@ func (suite *StoreSuite) TestGetFileMetadataWithCollectionPatching() {
 }
 
 func (suite *StoreSuite) TestGetFilesMetadataNoPatching() {
-	metadata1 := suite.generateMetadata(suite.defaultCollectionID)
+	metadata1 := suite.generateCollectionMetadata(suite.defaultCollectionID)
 	metadata1.Path += "1"
-	metadata2 := suite.generateMetadata(suite.defaultCollectionID)
+	metadata2 := suite.generateCollectionMetadata(suite.defaultCollectionID)
 	metadata2.Path += "2"
 
 	metadataColl := mock.MongoCollectionMock{
@@ -138,10 +138,10 @@ func (suite *StoreSuite) TestGetFilesMetadataNoPatching() {
 }
 
 func (suite *StoreSuite) TestGetFilesMetadataWithPatching() {
-	metadata1 := suite.generateMetadata(suite.defaultCollectionID)
+	metadata1 := suite.generateCollectionMetadata(suite.defaultCollectionID)
 	metadata1.Path += "1"
 	metadata1.State = store.StateUploaded
-	metadata2 := suite.generateMetadata(suite.defaultCollectionID)
+	metadata2 := suite.generateCollectionMetadata(suite.defaultCollectionID)
 	metadata2.Path += "2"
 	metadata2.State = store.StateUploaded
 
@@ -220,7 +220,7 @@ func (suite *StoreSuite) TestGetFilesMetadataFindError() {
 }
 
 func (suite *StoreSuite) TestGetFilesMetadataCollectionError() {
-	metadata := suite.generateMetadata(suite.defaultCollectionID)
+	metadata := suite.generateCollectionMetadata(suite.defaultCollectionID)
 	metadataColl := mock.MongoCollectionMock{
 		FindFunc: CollectionFindReturnsMetadataOnFilter(
 			[]files.StoredRegisteredMetaData{metadata},

--- a/store/metadata_retrieval_test.go
+++ b/store/metadata_retrieval_test.go
@@ -20,7 +20,7 @@ func (suite *StoreSuite) TestGetFileMetadataNotFoundError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collection, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	_, err := subject.GetFileMetadata(suite.defaultContext, suite.path)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -35,7 +35,7 @@ func (suite *StoreSuite) TestGetFileMetadataOtherError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collection, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	_, err := subject.GetFileMetadata(suite.defaultContext, suite.path)
 
 	suite.EqualError(err, "find error")
@@ -51,7 +51,7 @@ func (suite *StoreSuite) TestGetFileMetadataNoCollectionPatching() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collection, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	actualMetadata, _ := subject.GetFileMetadata(suite.defaultContext, suite.path)
 
 	suite.Exactly(expectedMetadata, actualMetadata)
@@ -73,7 +73,7 @@ func (suite *StoreSuite) TestGetFileMetadataCollectionError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&metadataColl, &collectionColl, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	actualMetadata, err := subject.GetFileMetadata(suite.defaultContext, suite.path)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -99,7 +99,7 @@ func (suite *StoreSuite) TestGetFileMetadataWithCollectionPatching() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&metadataColl, &collectionColl, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	actualMetadata, err := subject.GetFileMetadata(suite.defaultContext, suite.path)
 
 	suite.NoError(err)
@@ -128,7 +128,7 @@ func (suite *StoreSuite) TestGetFilesMetadataNoPatching() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&metadataColl, &collectionColl, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	expectedMetadata := []files.StoredRegisteredMetaData{metadata1, metadata2}
 	actualMetadata, err := subject.GetFilesMetadata(suite.defaultContext, suite.defaultCollectionID)
@@ -159,7 +159,7 @@ func (suite *StoreSuite) TestGetFilesMetadataWithPatching() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&metadataColl, &collectionColl, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	expectedMetadata := []files.StoredRegisteredMetaData{metadata1, metadata2}
 	expectedMetadata[0].State = store.StatePublished
@@ -193,7 +193,7 @@ func (suite *StoreSuite) TestGetFilesMetadataNoResult() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&metadataColl, &collectionColl, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	expectedMetadata := make([]files.StoredRegisteredMetaData, 0)
 	actualMetadata, err := subject.GetFilesMetadata(suite.defaultContext, "INVALID_COLLECTION_ID")
@@ -211,7 +211,7 @@ func (suite *StoreSuite) TestGetFilesMetadataFindError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&metadataColl, &collectionColl, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	actualMetadata, err := subject.GetFilesMetadata(suite.defaultContext, suite.defaultCollectionID)
 
@@ -232,7 +232,7 @@ func (suite *StoreSuite) TestGetFilesMetadataCollectionError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&metadataColl, &collectionColl, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&metadataColl, &collectionColl, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	actualMetadata, err := subject.GetFilesMetadata(suite.defaultContext, suite.defaultCollectionID)
 
@@ -241,7 +241,7 @@ func (suite *StoreSuite) TestGetFilesMetadataCollectionError() {
 }
 
 func (suite *StoreSuite) TestPatchMetadataNilMetadata() {
-	subject := store.NewStore(nil, nil, nil, suite.defaultClock, nil, nil)
+	subject := store.NewStore(nil, nil, nil, nil, suite.defaultClock, nil, nil)
 
 	var metadata *files.StoredRegisteredMetaData
 	collection := &files.StoredCollection{}
@@ -251,7 +251,7 @@ func (suite *StoreSuite) TestPatchMetadataNilMetadata() {
 }
 
 func (suite *StoreSuite) TestPatchMetadataNilCollection() {
-	subject := store.NewStore(nil, nil, nil, suite.defaultClock, nil, nil)
+	subject := store.NewStore(nil, nil, nil, nil, suite.defaultClock, nil, nil)
 
 	collectionID := "coll1"
 	metadata := files.StoredRegisteredMetaData{
@@ -266,7 +266,7 @@ func (suite *StoreSuite) TestPatchMetadataNilCollection() {
 }
 
 func (suite *StoreSuite) TestPatchMetadataNilCollectionID() {
-	subject := store.NewStore(nil, nil, nil, suite.defaultClock, nil, nil)
+	subject := store.NewStore(nil, nil, nil, nil, suite.defaultClock, nil, nil)
 
 	metadata := files.StoredRegisteredMetaData{
 		Path:  "path1",
@@ -284,7 +284,7 @@ func (suite *StoreSuite) TestPatchMetadataNilCollectionID() {
 }
 
 func (suite *StoreSuite) TestPatchMetadataCollectionIDMismatch() {
-	subject := store.NewStore(nil, nil, nil, suite.defaultClock, nil, nil)
+	subject := store.NewStore(nil, nil, nil, nil, suite.defaultClock, nil, nil)
 
 	collectionID := "coll1"
 	metadata := files.StoredRegisteredMetaData{
@@ -304,7 +304,7 @@ func (suite *StoreSuite) TestPatchMetadataCollectionIDMismatch() {
 }
 
 func (suite *StoreSuite) TestPatchMetadataBadState() {
-	subject := store.NewStore(nil, nil, nil, suite.defaultClock, nil, nil)
+	subject := store.NewStore(nil, nil, nil, nil, suite.defaultClock, nil, nil)
 
 	collectionID := "coll1"
 	metadata := files.StoredRegisteredMetaData{
@@ -324,7 +324,7 @@ func (suite *StoreSuite) TestPatchMetadataBadState() {
 }
 
 func (suite *StoreSuite) TestPatchMetadataBadCollectionState() {
-	subject := store.NewStore(nil, nil, nil, suite.defaultClock, nil, nil)
+	subject := store.NewStore(nil, nil, nil, nil, suite.defaultClock, nil, nil)
 
 	collectionID := "coll1"
 	metadata := files.StoredRegisteredMetaData{
@@ -343,7 +343,7 @@ func (suite *StoreSuite) TestPatchMetadataBadCollectionState() {
 }
 
 func (suite *StoreSuite) TestPatchMetadataSuccess() {
-	subject := store.NewStore(nil, nil, nil, suite.defaultClock, nil, nil)
+	subject := store.NewStore(nil, nil, nil, nil, suite.defaultClock, nil, nil)
 
 	collectionID := "coll1"
 	publishedAt := suite.generateTestTime(1)

--- a/store/state_changes.go
+++ b/store/state_changes.go
@@ -34,6 +34,8 @@ const (
 // @Failure      404
 // @Failure      500
 // @Router       /files [post]
+//
+//nolint:gocyclo // cyclomatic complexity is high (> 20) // acceptable for now
 func (store *Store) RegisterFileUpload(ctx context.Context, metaData files.StoredRegisteredMetaData) error {
 	logdata := log.Data{"path": metaData.Path}
 

--- a/store/state_changes_test.go
+++ b/store/state_changes_test.go
@@ -102,7 +102,7 @@ func (suite *StoreSuite) TestRegisterFileUploadWhenBundleAlreadyPublished() {
 	metadata := suite.generateBundleMetadata(suite.defaultBundleID)
 	metadata.State = store.StatePublished
 
-	bundle, _ := bson.Marshal(files.StoredCollection{
+	bundle, _ := bson.Marshal(files.StoredBundle{
 		State: store.StatePublished,
 	})
 	bundleCollection := mock.MongoCollectionMock{

--- a/store/state_changes_test.go
+++ b/store/state_changes_test.go
@@ -34,7 +34,7 @@ func (suite *StoreSuite) TestRegisterFileUploadCollectionPublishedCheckError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&metadataCollection, &collCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&metadataCollection, &collCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.RegisterFileUpload(suite.defaultContext, metadata)
 
 	suite.Equal(true, suite.logInterceptor.IsEventPresent("collection published check error"))
@@ -61,7 +61,7 @@ func (suite *StoreSuite) TestRegisterFileUploadWhenCollectionAlreadyPublished() 
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&metadataCollection, &collCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&metadataCollection, &collCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.RegisterFileUpload(suite.defaultContext, metadata)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -88,7 +88,7 @@ func (suite *StoreSuite) TestRegisterFileUploadWhenFilePathAlreadyExists() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&alwaysFindsExistingCollection, &emptyCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&alwaysFindsExistingCollection, &emptyCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.RegisterFileUpload(suite.defaultContext, metadata)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -136,7 +136,7 @@ func (suite *StoreSuite) TestRegisterFileUploadWhenFileDoesNotAlreadyExist() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionCountReturnsZero, &collCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionCountReturnsZero, &collCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.RegisterFileUpload(suite.defaultContext, metadata)
 
 	suite.NoError(err)
@@ -162,7 +162,7 @@ func (suite *StoreSuite) TestRegisterFileUploadInsertReturnsError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionCountReturnsZero, &emptyCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionCountReturnsZero, &emptyCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.RegisterFileUpload(suite.defaultContext, metadata)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -192,7 +192,7 @@ func (suite *StoreSuite) TestRegisterFileUploadInsertSucceeds() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionCountReturnsZero, &emptyCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionCountReturnsZero, &emptyCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.RegisterFileUpload(suite.defaultContext, metadata)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -222,7 +222,7 @@ func (suite *StoreSuite) TestRegisterFileUploadRegisterCollectionFails() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionCountReturnsZero, &emptyCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionCountReturnsZero, &emptyCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.RegisterFileUpload(suite.defaultContext, metadata)
 
 	suite.Equal(true, suite.logInterceptor.IsEventPresent("failed to register collection"))
@@ -259,7 +259,7 @@ func (suite *StoreSuite) TestMarkUploadCompleteFailsWhenNotInCreatedState() {
 		}
 
 		cfg, _ := config.Get()
-		subject := store.NewStore(&collectionWithUploadedFile, &emptyCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+		subject := store.NewStore(&collectionWithUploadedFile, &emptyCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 		err := subject.MarkUploadComplete(suite.defaultContext, suite.etagReference(metadata))
 
 		logEvents := suite.logInterceptor.GetLogEvents("update file state: state mismatch")
@@ -288,7 +288,7 @@ func (suite *StoreSuite) TestMarkUploadCompleteFailsWhenFileNotExists() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &emptyCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &emptyCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.MarkUploadComplete(suite.defaultContext, suite.etagReference(metadata))
 
 	logEvents := suite.logInterceptor.GetLogEvents("update file state: attempted to operate on unregistered file")
@@ -316,7 +316,7 @@ func (suite *StoreSuite) TestMarkUploadCompleteFailsWhenUpdateReturnsError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &collectionsCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &collectionsCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.MarkUploadComplete(suite.defaultContext, suite.etagReference(metadata))
 
 	suite.Error(err)
@@ -340,7 +340,7 @@ func (suite *StoreSuite) TestMarkUploadCompleteSucceeds() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &collectionsCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &collectionsCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.MarkUploadComplete(suite.defaultContext, suite.etagReference(metadata))
 
 	suite.NoError(err)
@@ -376,7 +376,7 @@ func (suite *StoreSuite) TestMarkFileMovedFailsWhenNotInCreatedState() {
 		}
 
 		cfg, _ := config.Get()
-		subject := store.NewStore(&collectionWithUploadedFile, &emptyCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+		subject := store.NewStore(&collectionWithUploadedFile, &emptyCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 		err := subject.MarkFileMoved(suite.defaultContext, suite.etagReference(metadata))
 
 		logEvents := suite.logInterceptor.GetLogEvents("update file state: state mismatch")
@@ -400,7 +400,7 @@ func (suite *StoreSuite) TestMarkFileMovedFailsWhenFileNotExists() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.MarkFileMoved(suite.defaultContext, suite.etagReference(metadata))
 
 	logEvents := suite.logInterceptor.GetLogEvents("update file state: attempted to operate on unregistered file")
@@ -436,7 +436,7 @@ func (suite *StoreSuite) TestMarkFileMovedFailsWhenUpdateReturnsError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &collectionsCollection, &suite.defaultKafkaProducer, suite.defaultClock, s3Client, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &collectionsCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, s3Client, cfg)
 	err := subject.MarkFileMoved(suite.defaultContext, suite.etagReference(metadata))
 
 	suite.Error(err)
@@ -466,7 +466,7 @@ func (suite *StoreSuite) TestMarkFileMovedEtagMismatch() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &collectionsCollection, &suite.defaultKafkaProducer, suite.defaultClock, s3Client, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &collectionsCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, s3Client, cfg)
 	err := subject.MarkFileMoved(suite.defaultContext, suite.etagReference(metadata))
 
 	suite.ErrorIs(err, store.ErrEtagMismatchWhilePublishing, "the actual err was %v", err)
@@ -495,7 +495,7 @@ func (suite *StoreSuite) TestMarkFileMovedSucceeds() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &collectionsCollection, &suite.defaultKafkaProducer, suite.defaultClock, s3Client, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &collectionsCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, s3Client, cfg)
 	err := subject.MarkFileMoved(suite.defaultContext, suite.etagReference(metadata))
 
 	suite.NoError(err)
@@ -510,7 +510,7 @@ func (suite *StoreSuite) TestMarkFilePublishedFindReturnsErrNoDocumentFound() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.MarkFilePublished(suite.defaultContext, suite.path)
 
 	logEvents := suite.logInterceptor.GetLogEvents("mark file as published: attempted to operate on unregistered file")
@@ -531,7 +531,7 @@ func (suite *StoreSuite) TestMarkFilePublishedFindReturnsUnspecifiedError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.MarkFilePublished(suite.defaultContext, suite.path)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -554,7 +554,7 @@ func (suite *StoreSuite) TestMarkFilePublishedCollectionIDNil() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 	err := subject.MarkFilePublished(suite.defaultContext, suite.path)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
@@ -584,7 +584,7 @@ func (suite *StoreSuite) TestMarkFilePublishedStateUploaded() {
 		}
 
 		cfg, _ := config.Get()
-		subject := store.NewStore(&collectionWithUploadedFile, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+		subject := store.NewStore(&collectionWithUploadedFile, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 		err := subject.MarkFilePublished(suite.defaultContext, suite.path)
 
 		logEvent := suite.logInterceptor.GetLogEvent()
@@ -613,7 +613,7 @@ func (suite *StoreSuite) TestMarkFilePublishedUpdateReturnsError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &emptyCollection, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &emptyCollection, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
 
 	err := subject.MarkFilePublished(suite.defaultContext, suite.path)
 
@@ -642,7 +642,7 @@ func (suite *StoreSuite) TestMarkFilePublishedUpdateKafkaReturnsError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &emptyCollection, &kafkaMock, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &emptyCollection, nil, &kafkaMock, suite.defaultClock, nil, cfg)
 
 	err := subject.MarkFilePublished(suite.defaultContext, suite.path)
 
@@ -671,7 +671,7 @@ func (suite *StoreSuite) TestMarkFilePublishedUpdateKafkaDoesNotReturnError() {
 	}
 
 	cfg, _ := config.Get()
-	subject := store.NewStore(&collectionWithUploadedFile, &emptyCollection, &kafkaMock, suite.defaultClock, nil, cfg)
+	subject := store.NewStore(&collectionWithUploadedFile, &emptyCollection, nil, &kafkaMock, suite.defaultClock, nil, cfg)
 
 	err := subject.MarkFilePublished(suite.defaultContext, suite.path)
 

--- a/store/store.go
+++ b/store/store.go
@@ -11,12 +11,13 @@ import (
 type Store struct {
 	metadataCollection    mongo.MongoCollection
 	collectionsCollection mongo.MongoCollection
+	bundlesCollection     mongo.MongoCollection
 	kafka                 kafka.IProducer
 	clock                 clock.Clock
 	s3client              aws.S3Clienter
 	cfg                   *config.Config
 }
 
-func NewStore(metadataCollection, collectionsCollection mongo.MongoCollection, kafkaProducer kafka.IProducer, clk clock.Clock, c aws.S3Clienter, cfg *config.Config) *Store {
-	return &Store{metadataCollection, collectionsCollection, kafkaProducer, clk, c, cfg}
+func NewStore(metadataCollection, collectionsCollection, bundlesCollection mongo.MongoCollection, kafkaProducer kafka.IProducer, clk clock.Clock, c aws.S3Clienter, cfg *config.Config) *Store {
+	return &Store{metadataCollection, collectionsCollection, bundlesCollection, kafkaProducer, clk, c, cfg}
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -30,6 +30,7 @@ type StoreSuite struct {
 	suite.Suite
 	logInterceptor       LogInterceptor
 	defaultCollectionID  string
+	defaultBundleID      string
 	path                 string
 	defaultContext       context.Context
 	defaultClock         steps.TestClock
@@ -211,6 +212,8 @@ func KafkaSendReturnsNil() KafkaSendFunc {
 
 func (suite *StoreSuite) SetupTest() {
 	suite.defaultCollectionID = "123456"
+	suite.defaultBundleID = "789"
+
 	suite.path = "test.txt"
 	suite.defaultContext = context.Background()
 	suite.defaultClock = steps.TestClock{}
@@ -241,7 +244,7 @@ func (suite *StoreSuite) generateTestTime(addedDuration time.Duration) time.Time
 	return time.Now().Add(time.Second * addedDuration).Round(time.Second).UTC()
 }
 
-func (suite *StoreSuite) generateMetadata(collectionID string) files.StoredRegisteredMetaData {
+func (suite *StoreSuite) generateCollectionMetadata(collectionID string) files.StoredRegisteredMetaData {
 	createdAt := suite.generateTestTime(1)
 	lastModified := suite.generateTestTime(2)
 	uploadCompletedAt := suite.generateTestTime(3)
@@ -252,6 +255,32 @@ func (suite *StoreSuite) generateMetadata(collectionID string) files.StoredRegis
 		Path:              suite.path,
 		IsPublishable:     true,
 		CollectionID:      &collectionID,
+		Title:             "Test file",
+		SizeInBytes:       10,
+		Type:              "text/plain",
+		Licence:           "MIT",
+		LicenceURL:        "https://opensource.org/licenses/MIT",
+		CreatedAt:         createdAt,
+		LastModified:      lastModified,
+		UploadCompletedAt: &uploadCompletedAt,
+		PublishedAt:       &publishedAt,
+		MovedAt:           &movedAt,
+		State:             store.StateMoved,
+		Etag:              "1234567",
+	}
+}
+
+func (suite *StoreSuite) generateBundleMetadata(bundleID string) files.StoredRegisteredMetaData {
+	createdAt := suite.generateTestTime(1)
+	lastModified := suite.generateTestTime(2)
+	uploadCompletedAt := suite.generateTestTime(3)
+	publishedAt := suite.generateTestTime(4)
+	movedAt := suite.generateTestTime(5)
+
+	return files.StoredRegisteredMetaData{
+		Path:              suite.path,
+		IsPublishable:     true,
+		BundleID:          &bundleID,
 		Title:             "Test file",
 		SizeInBytes:       10,
 		Type:              "text/plain",


### PR DESCRIPTION
### What

Allow `POST /files` to use `bundle_id` in the body of the request and write data to the new bundles collection.
Separate Collections and Bundles models to avoid confusion
Unit and component tests added

### How to review

Check changes make sense

- Run dataset-catalogue stack
- Make a POST request to `http://localhost:26900/files`
- Try with collection_id, bundle_id and neither
- Data should be written to the correct collection depending on which ID is provided

### Who can review

Anyone
