### PR TITLE
Feature/remove dependency on collection

### DIFF
--- a/api/patch_request_to_handler.go
+++ b/api/patch_request_to_handler.go
@@ -31,7 +31,7 @@ func PatchRequestToHandler(handlers PatchRequestHandlers) http.HandlerFunc {
 			return
 		}
 
-		if isCollectionIDUpdate(stateMetaData) {
+		if stateMetaData.CollectionID != nil && isCollectionIDUpdate(stateMetaData) {
 			handlers.CollectionUpdate.ServeHTTP(w, req)
 			return
 		}
@@ -51,7 +51,7 @@ func PatchRequestToHandler(handlers PatchRequestHandlers) http.HandlerFunc {
 }
 
 func isCollectionIDUpdate(stateMetaData StateMetadata) bool {
-	return stateMetaData.CollectionID != nil && stateMetaData.State == nil
+	return stateMetaData.State == nil
 }
 
 func getStateMetadataFromRequest(req *http.Request) (StateMetadata, error) {

--- a/features/mark_file_as_published.feature
+++ b/features/mark_file_as_published.feature
@@ -72,7 +72,7 @@ Feature: Mark single file as published
       | State             | UPLOADED                                                                  |
       | Etag              | 123456789                                                                 |
     When the file "images/meme.jpg" is marked as published
-    Then the HTTP status code should be "409"
+    Then the HTTP status code should be "200"
 
   Scenario: The one where the file does not exists
     Given I am an authorised user

--- a/store/state_changes.go
+++ b/store/state_changes.go
@@ -122,11 +122,6 @@ func (store *Store) MarkFilePublished(ctx context.Context, path string) error {
 	}
 	logdata["metadata"] = m
 
-	if m.CollectionID == nil {
-		log.Error(ctx, "file had no collection id", ErrCollectionIDNotSet, logdata)
-		return ErrCollectionIDNotSet
-	}
-
 	if m.State != StateUploaded {
 		log.Error(ctx, fmt.Sprintf("mark file published: file was not in state %s", StateUploaded),
 			ErrFileNotInUploadedState, logdata)
@@ -182,10 +177,12 @@ func (store *Store) updateFileState(ctx context.Context, path, etag, toState, ex
 	logdata["actualCurrentState"] = metadata.State
 
 	var isCollectionPublished bool
-	isCollectionPublished, err = store.IsCollectionPublished(ctx, *metadata.CollectionID) // also moved
-	if err != nil {
-		log.Error(ctx, "is collection published: caught db error", err, logdata)
-		return err
+	if metadata.CollectionID != nil {
+		isCollectionPublished, err = store.IsCollectionPublished(ctx, *metadata.CollectionID) // also moved
+		if err != nil {
+			log.Error(ctx, "is collection published: caught db error", err, logdata)
+			return err
+		}
 	}
 
 	// update only timestamps if we are already in uploaded state

--- a/store/state_changes_test.go
+++ b/store/state_changes_test.go
@@ -558,10 +558,9 @@ func (suite *StoreSuite) TestMarkFilePublishedCollectionIDNil() {
 	err := subject.MarkFilePublished(suite.defaultContext, suite.path)
 
 	logEvent := suite.logInterceptor.GetLogEvent()
-
-	suite.Equal("file had no collection id", logEvent)
+	suite.Equal("mark file published: file was not in state UPLOADED", logEvent)
 	suite.Error(err)
-	suite.ErrorIs(err, store.ErrCollectionIDNotSet)
+	suite.ErrorIs(err, store.ErrFileNotInUploadedState)
 }
 
 func (suite *StoreSuite) TestMarkFilePublishedStateUploaded() {


### PR DESCRIPTION
### What

- removed the collectionID dependency from patch requests
- updated unit tests

### How to review

- Check if the changes make sense
- try running following endpoints in order

1.  POST /upload-new via dp-upload-service - this sends the file to the encrypted bucket and registers the file metadata in the metadata collection in the files database.
2. PATCH /files/{path-to-file} in dp-files-api with a body of { "state" : "PUBLISHED" } - this triggers the publish process for a single file, which will then be moved to the static bucket and the metadata for the file will contain the status of MOVED.

### Who can review

anyone