### PR TITLE
Fetaure/amend update bundleid

### DIFF
--- a/features/update_bundle_id.feature
+++ b/features/update_bundle_id.feature
@@ -67,3 +67,34 @@ Feature: Updating a file's bundle ID
       | State         | CREATED                                                                   |
     When I set the bundle ID to "forbidden-bundle" for file "images/unauthorised.jpg"
     Then the HTTP status code should be "403"
+
+Scenario: Removing a bundle ID from a file
+  Given I am an authorised user
+  And the file upload "images/with-bundle.jpg" has been registered with:
+    | IsPublishable | true                                                                      |
+    | BundleID      | existing-bundle-789                                                       |
+    | Title         | Image with existing bundle                                                |
+    | SizeInBytes   | 14794                                                                     |
+    | Type          | image/jpeg                                                                |
+    | Licence       | OGL v3                                                                    |
+    | LicenceURL    | http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+    | CreatedAt     | 2021-10-21T15:13:14Z                                                      |
+    | LastModified  | 2021-10-21T15:13:14Z                                                      |
+    | State         | CREATED                                                                   |
+  When I set the bundle ID to "" for file "images/with-bundle.jpg"
+  Then the HTTP status code should be "200"
+  When the file metadata is requested for the file "images/with-bundle.jpg"
+  Then I should receive the following JSON response with status "200":
+  """
+  {
+    "path": "images/with-bundle.jpg",
+    "is_publishable": true,
+    "title": "Image with existing bundle",
+    "size_in_bytes": 14794,
+    "type": "image/jpeg",
+    "licence": "OGL v3",
+    "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+    "state": "CREATED",
+    "etag": ""
+  }
+  """

--- a/store/bundle_operations.go
+++ b/store/bundle_operations.go
@@ -231,6 +231,7 @@ func (store *Store) UpdateBundleID(ctx context.Context, path, bundleID string) e
 		return ErrBundleIDAlreadySet
 	}
 
+	// check to see if bundleID exists and is not-published
 	published, err := store.IsBundlePublished(ctx, bundleID)
 	if err != nil {
 		log.Error(ctx, "update bundle ID: caught db error", err, logdata)


### PR DESCRIPTION
### What

Update the PATCH /files/{filepath} endpoint to allow `bundle_id` to be an empty string.
This allows us to disassociate the bundle ID from the file

### How to review

Make a PATCH request to /files/{filepath} (using a file already associated with a bundle) with an empty bundle ID and confirm in local mongo that the bundle ID is no longer associated with the file
Confirm changes make sense, tests pass

### Who can review

Anyone
