### PR TITLE
Add validation to stop bundle id update if file is moved

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -46,6 +46,8 @@ func handleError(w http.ResponseWriter, err error) {
 		writeError(w, buildErrors(err, "FileNotPublishable"), http.StatusConflict)
 	case store.ErrBothCollectionAndBundleIDSet:
 		writeError(w, buildErrors(err, "BothCollectionAndBundleIDSet"), http.StatusBadRequest)
+	case store.ErrFileMoved:
+		writeError(w, buildErrors(err, "FileMoved"), http.StatusConflict)
 	default:
 		writeError(w, buildErrors(err, "InternalError"), http.StatusInternalServerError)
 	}

--- a/api/update_bundle_id.go
+++ b/api/update_bundle_id.go
@@ -26,5 +26,6 @@ func HandlerUpdateBundleID(updateBundleID UpdateBundleID) http.HandlerFunc {
 			handleError(w, err)
 			return
 		}
+		w.WriteHeader(http.StatusOK)
 	}
 }

--- a/features/update_bundle_id.feature
+++ b/features/update_bundle_id.feature
@@ -31,7 +31,7 @@ Feature: Updating a file's bundle ID
     }
     """
 
-  Scenario: Error when setting a bundle ID for a file that already has one
+  Scenario: Success when setting a bundle ID for a file that already has one
     Given I am an authorised user
     And the file upload "images/with-bundle.jpg" has been registered with:
       | IsPublishable | true                                                                      |
@@ -45,8 +45,56 @@ Feature: Updating a file's bundle ID
       | LastModified  | 2021-10-21T15:13:14Z                                                      |
       | State         | CREATED                                                                   |
     When I set the bundle ID to "another-bundle-999" for file "images/with-bundle.jpg"
-    Then the HTTP status code should be "400"
-    
+    Then the HTTP status code should be "200"
+    When the file metadata is requested for the file "images/with-bundle.jpg"
+    Then I should receive the following JSON response with status "200":
+    """
+    {
+      "path": "images/with-bundle.jpg",
+      "is_publishable": true,
+      "bundle_id": "another-bundle-999",
+      "title": "Image with existing bundle",
+      "size_in_bytes": 14794,
+      "type": "image/jpeg",
+      "licence": "OGL v3",
+      "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+      "state": "CREATED",
+      "etag": ""
+    }
+    """
+
+  Scenario: Error when setting a bundle ID for a file that already has one and is in MOVED state
+    Given I am an authorised user
+    And the file upload "images/with-bundle.jpg" has been registered with:
+      | IsPublishable | true                                                                      |
+      | BundleID      | existing-bundle-789                                                       |
+      | Title         | Image with existing bundle                                                |
+      | SizeInBytes   | 14794                                                                     |
+      | Type          | image/jpeg                                                                |
+      | Licence       | OGL v3                                                                    |
+      | LicenceURL    | http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+      | CreatedAt     | 2021-10-21T15:13:14Z                                                      |
+      | LastModified  | 2021-10-21T15:13:14Z                                                      |
+      | State         | MOVED                                                                     |
+    When I set the bundle ID to "another-bundle-999" for file "images/with-bundle.jpg"
+    Then the HTTP status code should be "409"
+    When the file metadata is requested for the file "images/with-bundle.jpg"
+    Then I should receive the following JSON response with status "200":
+    """
+    {
+      "path": "images/with-bundle.jpg",
+      "is_publishable": true,
+      "bundle_id": "existing-bundle-789",
+      "title": "Image with existing bundle",
+      "size_in_bytes": 14794,
+      "type": "image/jpeg",
+      "licence": "OGL v3",
+      "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+      "state": "MOVED",
+      "etag": ""
+    }
+    """
+
   Scenario: Error when setting a bundle ID for a file that has not been registered
     Given I am an authorised user
     And the file "images/not-registered.jpg" has not been registered
@@ -95,6 +143,38 @@ Scenario: Removing a bundle ID from a file
     "licence": "OGL v3",
     "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
     "state": "CREATED",
+    "etag": ""
+  }
+  """
+
+  Scenario: Error when removing a bundle ID from a file that is in MOVED state
+    Given I am an authorised user
+    And the file upload "images/with-bundle.jpg" has been registered with:
+      | IsPublishable | true                                                                      |
+      | BundleID      | existing-bundle-789                                                       |
+      | Title         | Image with existing bundle                                                |
+      | SizeInBytes   | 14794                                                                     |
+      | Type          | image/jpeg                                                                |
+      | Licence       | OGL v3                                                                    |
+      | LicenceURL    | http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+      | CreatedAt     | 2021-10-21T15:13:14Z                                                      |
+      | LastModified  | 2021-10-21T15:13:14Z                                                      |
+      | State         | MOVED                                                                     |
+    When I set the bundle ID to "" for file "images/with-bundle.jpg"
+    Then the HTTP status code should be "409"
+    When the file metadata is requested for the file "images/with-bundle.jpg"
+    Then I should receive the following JSON response with status "200":
+  """
+  {
+    "path": "images/with-bundle.jpg",
+    "is_publishable": true,
+    "bundle_id": "existing-bundle-789",
+    "title": "Image with existing bundle",
+    "size_in_bytes": 14794,
+    "type": "image/jpeg",
+    "licence": "OGL v3",
+    "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+    "state": "MOVED",
     "etag": ""
   }
   """

--- a/store/bundle_operations.go
+++ b/store/bundle_operations.go
@@ -205,6 +205,11 @@ func (store *Store) UpdateBundleID(ctx context.Context, path, bundleID string) e
 		return err
 	}
 
+	if metadata.State == StateMoved {
+		log.Error(ctx, "update bundle ID: attempted to operate on a moved file", ErrFileMoved, logdata)
+		return ErrFileMoved
+	}
+
 	if bundleID == "" {
 		if metadata.BundleID == nil {
 			return nil
@@ -223,12 +228,6 @@ func (store *Store) UpdateBundleID(ctx context.Context, path, bundleID string) e
 			log.Error(ctx, "failed to remove bundle ID", err, logdata)
 		}
 		return err
-	}
-
-	if metadata.BundleID != nil {
-		logdata["bundle_id"] = *metadata.BundleID
-		log.Error(ctx, "update bundle ID: bundle ID already set", ErrBundleIDAlreadySet, logdata)
-		return ErrBundleIDAlreadySet
 	}
 
 	// check to see if bundleID exists and is not-published

--- a/store/errors.go
+++ b/store/errors.go
@@ -20,4 +20,5 @@ var (
 	ErrEtagMismatchWhilePublishing     = errors.New("etag mismatch")
 	ErrBundleIDAlreadySet              = errors.New("bundle ID already set")
 	ErrBothCollectionAndBundleIDSet    = errors.New("cannot set both collection and bundle ID")
+	ErrFileMoved                       = errors.New("record cannot be updated as the file is MOVED")
 )


### PR DESCRIPTION
### What

Add validation to stop bundle id update if file is moved 
Jira ticket: https://jira.ons.gov.uk/browse/DIS-3019

### How to review

Check changes make sense and acceptance criteria met

- Run the dataset catalogue stack
- Create a post request to http://localhost:26900/files to register a new file upload
- Create a patch request to http://localhost:26900/files/{filepath} to change the file status to uploaded
the body should be something like this 
{
  "state": "UPLOADED",
  "etag": "194577a7e20bdcc7afbb718f502c134c"
}
At this point we need to add also the file to the private bucket example :
export LOCALSTACK_ENDPOINT=http://localhost:14566
aws --endpoint-url=$LOCALSTACK_ENDPOINT s3 cp meme.jpg s3://testing/images/meme.jpg
- Make a patch request to http://localhost:26900/files/{filepath} to change the bundle id to a non-empty string and to an empty string, both should succeed
- Make a patch request to http://localhost:26900/files/{filepath} to change the state of the file to PUBLISHED
file should move to the public bucket and the state of the file should change to MOVED
- Make a patch request to http://localhost:26900/files/{filepath} to change the bundle id to a non-empty string and to an empty string, both should be unsuccessful with a status code of 409 

### Who can review

Anyone
