### PR TITLE
feat: correct responses sent in web mode

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -50,7 +50,8 @@ func handleError(w http.ResponseWriter, err error) {
 		writeError(w, buildErrors(err, "FileMoved"), http.StatusConflict)
 	case store.ErrFileIsPublished:
 		writeError(w, buildErrors(err, "FileIsPublished"), http.StatusConflict)
-	case store.ErrPathNotFound:
+	case store.ErrPathNotFound,
+		store.ErrFileIsNotPublished:
 		writeError(w, buildErrors(err, "NotFound"), http.StatusNotFound)
 	default:
 		writeError(w, buildErrors(err, "InternalError"), http.StatusInternalServerError)

--- a/api/get_metadata.go
+++ b/api/get_metadata.go
@@ -16,6 +16,8 @@ import (
 
 type GetFileMetadata func(ctx context.Context, path string) (files.StoredRegisteredMetaData, error)
 
+type GetFileMetadataWeb func(ctx context.Context, path string) (files.StoredRegisteredMetaData, error)
+
 func HandleGetFileMetadataWithAuth(getMetadata GetFileMetadata, authMiddleware auth.Middleware, idClient *clientsidentity.Client, permissionsChecker auth.PermissionsChecker) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		vars := mux.Vars(req)
@@ -84,7 +86,7 @@ func HandleGetFileMetadataWithAuth(getMetadata GetFileMetadata, authMiddleware a
 	}
 }
 
-func HandleGetFileMetadata(getMetadata GetFileMetadata) http.HandlerFunc {
+func HandleGetFileMetadata(getMetadata GetFileMetadataWeb) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		vars := mux.Vars(req)
 		w.Header().Add("Content-Type", "application/json")

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -70,6 +70,8 @@ func (c *FilesAPIComponent) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I update the content item of the file "([^"]*)" with:`, c.iUpdateTheContentItemOfTheFileWith)
 	ctx.Step(`^a READ audit event should be created for the file-events endpoint$`, c.aReadAuditEventShouldBeCreatedForFileEvents)
 	ctx.Step(`^an UPDATE audit event should be created for file "([^"]*)"$`, c.anUpdateAuditEventShouldBeCreatedForFile)
+	ctx.Step(`the collection with ID "([^"]*)" is published`, c.theCollectionIsPublished)
+	ctx.Step(`the bundle with ID "([^"]*)" is published`, c.theBundleIsPublished)
 }
 
 func (c *FilesAPIComponent) iAmAnAuthorisedUser() error {
@@ -275,6 +277,26 @@ func (c *FilesAPIComponent) theFileUploadHasBeenRegistered(path string) error {
 	_, err := c.mongoClient.Database("files").Collection("metadata").InsertOne(ctx, &m)
 	assert.NoError(c.APIFeature, err)
 
+	return c.APIFeature.StepError()
+}
+
+func (c *FilesAPIComponent) theCollectionIsPublished(collectionID string) error {
+	ctx := context.Background()
+
+	coll := files.StoredCollection{ID: collectionID, State: store.StatePublished}
+
+	_, err := c.mongoClient.Database("files").Collection("collections").InsertOne(ctx, &coll)
+	assert.NoError(c.APIFeature, err)
+	return c.APIFeature.StepError()
+}
+
+func (c *FilesAPIComponent) theBundleIsPublished(bundleID string) error {
+	ctx := context.Background()
+
+	bundle := files.StoredBundle{ID: bundleID, State: store.StatePublished}
+
+	_, err := c.mongoClient.Database("files").Collection("bundles").InsertOne(ctx, &bundle)
+	assert.NoError(c.APIFeature, err)
 	return c.APIFeature.StepError()
 }
 

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -61,6 +61,8 @@ func (c *FilesAPIComponent) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I update the content item of the file "([^"]*)" with:`, c.iUpdateTheContentItemOfTheFileWith)
 	ctx.Step(`^a READ audit event should be created for the file-events endpoint$`, c.aReadAuditEventShouldBeCreatedForFileEvents)
 	ctx.Step(`^an UPDATE audit event should be created for file "([^"]*)"$`, c.anUpdateAuditEventShouldBeCreatedForFile)
+	ctx.Step(`the collection with ID "([^"]*)" is published`, c.theCollectionIsPublished)
+	ctx.Step(`the bundle with ID "([^"]*)" is published`, c.theBundleIsPublished)
 }
 
 func (c *FilesAPIComponent) iAmAnAuthorisedUser() error {
@@ -182,6 +184,26 @@ func (c *FilesAPIComponent) theFileUploadHasBeenRegistered(path string) error {
 	_, err := c.mongoClient.Database("files").Collection("metadata").InsertOne(ctx, &m)
 	assert.NoError(c.APIFeature, err)
 
+	return c.APIFeature.StepError()
+}
+
+func (c *FilesAPIComponent) theCollectionIsPublished(collectionID string) error {
+	ctx := context.Background()
+
+	coll := files.StoredCollection{ID: collectionID, State: store.StatePublished}
+
+	_, err := c.mongoClient.Database("files").Collection("collections").InsertOne(ctx, &coll)
+	assert.NoError(c.APIFeature, err)
+	return c.APIFeature.StepError()
+}
+
+func (c *FilesAPIComponent) theBundleIsPublished(bundleID string) error {
+	ctx := context.Background()
+
+	bundle := files.StoredBundle{ID: bundleID, State: store.StatePublished}
+
+	_, err := c.mongoClient.Database("files").Collection("bundles").InsertOne(ctx, &bundle)
+	assert.NoError(c.APIFeature, err)
 	return c.APIFeature.StepError()
 }
 

--- a/features/web_mode.feature
+++ b/features/web_mode.feature
@@ -78,7 +78,7 @@ Feature: Web mode restrictions
     When the file "images/meme.jpg" is marked as moved with etag "987654321"
     Then the HTTP status code should be "403"
 
-  Scenario: The one where I try to get a file
+  Scenario: The one where I try to get a file (state CREATED)
     Given the file upload "images/meme.jpg" has been registered with:
       | IsPublishable | true                                                                      |
       | CollectionID  | 1234-asdfg-54321-qwerty                                                   |
@@ -90,5 +90,81 @@ Feature: Web mode restrictions
       | CreatedAt     | 2021-10-21T15:13:14Z                                                      |
       | LastModified  | 2021-10-21T15:13:14Z                                                      |
       | State         | CREATED                                                                   |
+    When the file metadata is requested for the file "images/meme.jpg"
+    Then the HTTP status code should be "404"
+
+  Scenario: The one where I try to get a file (state UPLOADED)
+    Given the file upload "images/meme.jpg" has been completed with:
+      | IsPublishable | true                                                                      |
+      | Title         | The latest Meme                                                           |
+      | SizeInBytes   | 14794                                                                     |
+      | Type          | image/jpeg                                                                |
+      | Licence       | OGL v3                                                                    |
+      | LicenceURL    | http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+      | CreatedAt     | 2021-10-21T15:13:14Z                                                      |
+      | LastModified  | 2021-10-21T15:13:14Z                                                      |
+      | State         | UPLOADED                                                                  |
+    When the file metadata is requested for the file "images/meme.jpg"
+    Then the HTTP status code should be "404"
+
+  Scenario: The one where I try to get a file (state UPLOADED)
+    Given the file upload "images/meme.jpg" has been completed with:
+      | IsPublishable | true                                                                      |
+      | CollectionID  | 1234-asdfg-54321-qwerty                                                   |
+      | Title         | The latest Meme                                                           |
+      | SizeInBytes   | 14794                                                                     |
+      | Type          | image/jpeg                                                                |
+      | Licence       | OGL v3                                                                    |
+      | LicenceURL    | http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+      | CreatedAt     | 2021-10-21T15:13:14Z                                                      |
+      | LastModified  | 2021-10-21T15:13:14Z                                                      |
+      | State         | UPLOADED                                                                  |
+    And the collection with ID "1234-asdfg-54321-qwerty" is published
+    When the file metadata is requested for the file "images/meme.jpg"
+    Then the HTTP status code should be "200"
+
+    Scenario: The one where I try to get a file (state UPLOADED)
+    Given the file upload "images/meme.jpg" has been completed with:
+      | IsPublishable | true                                                                      |
+      | BundleID      | 1234-asdfg-54321-qwerty                                                   |
+      | Title         | The latest Meme                                                           |
+      | SizeInBytes   | 14794                                                                     |
+      | Type          | image/jpeg                                                                |
+      | Licence       | OGL v3                                                                    |
+      | LicenceURL    | http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+      | CreatedAt     | 2021-10-21T15:13:14Z                                                      |
+      | LastModified  | 2021-10-21T15:13:14Z                                                      |
+      | State         | UPLOADED                                                                  |
+    And the bundle with ID "1234-asdfg-54321-qwerty" is published
+    When the file metadata is requested for the file "images/meme.jpg"
+    Then the HTTP status code should be "200"
+
+  Scenario: The one where I try to get a file (state MOVED)
+    Given the file upload "images/meme.jpg" has been registered with:
+      | IsPublishable | true                                                                      |
+      | CollectionID  | 1234-asdfg-54321-qwerty                                                   |
+      | Title         | The latest Meme                                                           |
+      | SizeInBytes   | 14794                                                                     |
+      | Type          | image/jpeg                                                                |
+      | Licence       | OGL v3                                                                    |
+      | LicenceURL    | http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+      | CreatedAt     | 2021-10-21T15:13:14Z                                                      |
+      | LastModified  | 2021-10-21T15:13:14Z                                                      |
+      | State         | MOVED                                                                   |
+    When the file metadata is requested for the file "images/meme.jpg"
+    Then the HTTP status code should be "200"
+
+  Scenario: The one where I try to get a file (state PUBLISHED)
+    Given the file upload "images/meme.jpg" has been registered with:
+      | IsPublishable | true                                                                      |
+      | CollectionID  | 1234-asdfg-54321-qwerty                                                   |
+      | Title         | The latest Meme                                                           |
+      | SizeInBytes   | 14794                                                                     |
+      | Type          | image/jpeg                                                                |
+      | Licence       | OGL v3                                                                    |
+      | LicenceURL    | http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/ |
+      | CreatedAt     | 2021-10-21T15:13:14Z                                                      |
+      | LastModified  | 2021-10-21T15:13:14Z                                                      |
+      | State         | PUBLISHED                                                                   |
     When the file metadata is requested for the file "images/meme.jpg"
     Then the HTTP status code should be "200"

--- a/sdk/file_get.go
+++ b/sdk/file_get.go
@@ -6,11 +6,14 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/ONSdigital/log.go/v2/log"
+
 	"github.com/ONSdigital/dp-files-api/files"
 )
 
 // GetFile retrieves the metadata for a file at the specified path
 func (c *Client) GetFile(ctx context.Context, filePath string, headers Headers) (*files.StoredRegisteredMetaData, error) {
+	log.Info(ctx, "Hello from the Files API SDK")
 	parsedURL, err := url.Parse(c.hcCli.URL + "/files")
 	if err != nil {
 		return nil, err

--- a/sdk/file_get.go
+++ b/sdk/file_get.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/ONSdigital/dp-files-api/files"
+	"github.com/ONSdigital/dp-files-api/store"
 )
 
 // GetFile retrieves the metadata for a file at the specified path
@@ -51,4 +52,47 @@ func (c *Client) GetFile(ctx context.Context, filePath string, headers Headers) 
 	}
 
 	return metadata, nil
+}
+
+func (c *Client) GetFileWithBundleState(ctx context.Context, filePath string, headers Headers) (*files.StoredRegisteredMetaData, string, error) {
+	parsedURL, err := url.Parse(c.hcCli.URL + "/files")
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Remove leading slash so that JoinPath works if filePath starts with or without a "/"
+	cleanedFilePath := strings.TrimPrefix(filePath, "/")
+	parsedURL = parsedURL.JoinPath(cleanedFilePath)
+
+	req, err := http.NewRequest(http.MethodGet, parsedURL.String(), http.NoBody)
+	if err != nil {
+		return nil, "", err
+	}
+
+	headers.Add(req)
+
+	resp, err := c.hcCli.Client.Do(ctx, req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer closeResponseBody(ctx, resp)
+
+	statusCode := resp.StatusCode
+	if statusCode != http.StatusOK {
+		jsonErrors, unmarshalErr := unmarshalJSONErrors(ctx, resp.Body)
+		if unmarshalErr != nil {
+			return nil, "", unmarshalErr
+		}
+		return nil, "", &APIError{
+			StatusCode: statusCode,
+			Errors:     jsonErrors,
+		}
+	}
+
+	metadata, err := unmarshalStoredRegisteredMetaData(resp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return metadata, store.StatePublished, nil
 }

--- a/sdk/file_get.go
+++ b/sdk/file_get.go
@@ -6,14 +6,11 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/ONSdigital/log.go/v2/log"
-
 	"github.com/ONSdigital/dp-files-api/files"
 )
 
 // GetFile retrieves the metadata for a file at the specified path
 func (c *Client) GetFile(ctx context.Context, filePath string, headers Headers) (*files.StoredRegisteredMetaData, error) {
-	log.Info(ctx, "Hello from the Files API SDK")
 	parsedURL, err := url.Parse(c.hcCli.URL + "/files")
 	if err != nil {
 		return nil, err

--- a/service/service.go
+++ b/service/service.go
@@ -118,7 +118,7 @@ func Run(ctx context.Context, serviceList ServiceContainer, svcErrors chan error
 		r.Path("/bundle/{bundle-id}").HandlerFunc(forbiddenHandler).Methods(http.MethodPatch)
 
 		// simple scenario - web mode where users are not authenticated - allowed based on publishing status
-		r.Path(filesURI).HandlerFunc(api.HandleGetFileMetadata(dataStore.GetFileMetadata)).Methods(http.MethodGet)
+		r.Path(filesURI).HandlerFunc(api.HandleGetFileMetadata(dataStore.GetFileMetadataWeb)).Methods(http.MethodGet)
 	}
 	r.Path("/health").HandlerFunc(hc.Handler)
 

--- a/store/errors.go
+++ b/store/errors.go
@@ -22,6 +22,7 @@ var (
 	ErrBothCollectionAndBundleIDSet    = errors.New("cannot set both collection and bundle ID")
 	ErrFileMoved                       = errors.New("record cannot be updated as the file is MOVED")
 	ErrFileIsPublished                 = errors.New("cannot delete file as it is already published")
+	ErrFileIsNotPublished              = errors.New("file is not published or in published bundle/collection")
 	ErrPathNotFound                    = errors.New("the requested resource does not exist")
 	ErrInvalidPagination               = errors.New("unable to process request due to a malformed or invalid request body or query parameter")
 )

--- a/store/metadata_retrieval.go
+++ b/store/metadata_retrieval.go
@@ -45,6 +45,51 @@ func (store *Store) GetFileMetadata(ctx context.Context, path string) (files.Sto
 	return fileMetadata, nil
 }
 
+func (store *Store) GetFileMetadataWeb(ctx context.Context, path string) (files.StoredRegisteredMetaData, error) {
+	fileMetadata := files.StoredRegisteredMetaData{}
+
+	err := store.metadataCollection.FindOne(ctx, bson.M{fieldPath: path}, &fileMetadata)
+	if err != nil {
+		if errors.Is(err, mongodriver.ErrNoDocumentFound) {
+			log.Error(ctx, "file metadata not found", err, log.Data{"path": path})
+			return files.StoredRegisteredMetaData{}, ErrFileNotRegistered
+		}
+		return files.StoredRegisteredMetaData{}, err
+	}
+
+	switch fileMetadata.State {
+	case StateUploaded:
+		if fileMetadata.CollectionID != nil {
+			collectionPublishedMetadata, err := store.GetCollectionPublishedMetadata(ctx, *fileMetadata.CollectionID)
+
+			if err != nil {
+				return files.StoredRegisteredMetaData{}, err
+			}
+
+			if collectionPublishedMetadata.State == StatePublished {
+				return fileMetadata, nil
+			}
+		} else if fileMetadata.BundleID != nil {
+			bundlePublishedMetadata, err := store.GetBundlePublishedMetadata(ctx, *fileMetadata.BundleID)
+
+			if err != nil {
+				return files.StoredRegisteredMetaData{}, err
+			}
+
+			if bundlePublishedMetadata.State == StatePublished {
+				return fileMetadata, nil
+			}
+		} else {
+			return files.StoredRegisteredMetaData{}, ErrFileIsNotPublished
+		}
+	case StateMoved, StatePublished:
+		return fileMetadata, nil
+	default:
+		return files.StoredRegisteredMetaData{}, ErrFileIsNotPublished
+	}
+	return files.StoredRegisteredMetaData{}, ErrFileIsNotPublished
+}
+
 // GetFilesMetadata godoc
 // @Description  GETs metadata for a file
 // @Tags         File upload started

--- a/store/metadata_retrieval_test.go
+++ b/store/metadata_retrieval_test.go
@@ -179,6 +179,157 @@ func (suite *StoreSuite) TestGetFileMetadataWithBundleError() {
 	suite.Equal(expectedMetadata, actualMetadata)
 }
 
+func (suite *StoreSuite) TestGetFileMetadataWebNotFoundError() {
+	suite.logInterceptor.Start()
+	defer suite.logInterceptor.Stop()
+
+	collection := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(mongodriver.ErrNoDocumentFound),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(&collection, nil, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	_, err := subject.GetFileMetadataWeb(suite.defaultContext, suite.path)
+
+	logEvent := suite.logInterceptor.GetLogEvent()
+
+	suite.Equal("file metadata not found", logEvent)
+	suite.Equal(store.ErrFileNotRegistered, err)
+}
+
+func (suite *StoreSuite) TestGetFileMetadataWebOtherError() {
+	collection := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(errors.New("find error")),
+	}
+	cfg, _ := config.Get()
+	subject := store.NewStore(&collection, nil, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	_, err := subject.GetFileMetadataWeb(suite.defaultContext, suite.path)
+
+	suite.EqualError(err, "find error")
+}
+
+func (suite *StoreSuite) TestGetFileMetadataWebWithCollectionID() {
+	collectionID := testCollectionID
+	expectedMetadata := files.StoredRegisteredMetaData{
+		Path:     suite.path,
+		State:    store.StateUploaded,
+		BundleID: &collectionID,
+	}
+
+	metadataBytes, _ := bson.Marshal(expectedMetadata)
+
+	metadataColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(metadataBytes),
+	}
+
+	lastModified := suite.generateTestTime(2)
+	collection := files.StoredCollection{
+		ID:           collectionID,
+		State:        store.StatePublished,
+		LastModified: lastModified,
+	}
+	collectionBytes, _ := bson.Marshal(collection)
+
+	collectionColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(collectionBytes),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(&metadataColl, nil, &collectionColl, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+
+	actualMetadata, err := subject.GetFileMetadataWeb(suite.defaultContext, suite.path)
+
+	suite.NoError(err)
+	suite.Exactly(expectedMetadata, actualMetadata)
+}
+
+func (suite *StoreSuite) TestGetFileMetadataWebCollectionError() {
+	suite.logInterceptor.Start()
+	defer suite.logInterceptor.Stop()
+
+	expectedMetadata := suite.generateCollectionMetadata(suite.defaultCollectionID)
+	expectedMetadata.State = store.StateUploaded
+	metadataBytes, _ := bson.Marshal(expectedMetadata)
+
+	metadataColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(metadataBytes),
+	}
+	collectionColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(errors.New("collection error")),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(&metadataColl, &collectionColl, nil, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+	_, err := subject.GetFileMetadataWeb(suite.defaultContext, suite.path)
+
+	logEvent := suite.logInterceptor.GetLogEvent()
+
+	suite.Equal("collection metadata fetch error", logEvent)
+	suite.EqualError(err, "collection error")
+}
+
+func (suite *StoreSuite) TestGetFileMetadataWebWithBundleID() {
+	bundleID := testBundleID
+	expectedMetadata := files.StoredRegisteredMetaData{
+		Path:     suite.path,
+		State:    store.StateUploaded,
+		BundleID: &bundleID,
+	}
+
+	metadataBytes, _ := bson.Marshal(expectedMetadata)
+
+	metadataColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(metadataBytes),
+	}
+
+	lastModified := suite.generateTestTime(2)
+	bundle := files.StoredBundle{
+		ID:           bundleID,
+		State:        store.StatePublished,
+		LastModified: lastModified,
+	}
+	bundleBytes, _ := bson.Marshal(bundle)
+
+	bundleColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(bundleBytes),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(&metadataColl, nil, &bundleColl, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+
+	actualMetadata, err := subject.GetFileMetadataWeb(suite.defaultContext, suite.path)
+
+	suite.NoError(err)
+	suite.Exactly(expectedMetadata, actualMetadata)
+}
+
+func (suite *StoreSuite) TestGetFileMetadataWebBundleError() {
+	bundleID := testBundleID
+	expectedMetadata := files.StoredRegisteredMetaData{
+		Path:     suite.path,
+		State:    store.StateUploaded,
+		BundleID: &bundleID,
+	}
+
+	metadataBytes, _ := bson.Marshal(expectedMetadata)
+
+	metadataColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneSetsResultAndReturnsNil(metadataBytes),
+	}
+
+	bundleColl := mock.MongoCollectionMock{
+		FindOneFunc: CollectionFindOneReturnsError(errors.New("bundle error")),
+	}
+
+	cfg, _ := config.Get()
+	subject := store.NewStore(&metadataColl, nil, &bundleColl, nil, &suite.defaultKafkaProducer, suite.defaultClock, nil, cfg)
+
+	actualMetadata, err := subject.GetFileMetadataWeb(suite.defaultContext, suite.path)
+
+	suite.Error(err)
+	suite.Equal(files.StoredRegisteredMetaData{}, actualMetadata)
+}
+
 func (suite *StoreSuite) TestGetFilesMetadataNoPatching() {
 	metadata1 := suite.generateCollectionMetadata(suite.defaultCollectionID)
 	metadata1.Path += "1"


### PR DESCRIPTION
### What

Added a new Store method (`GetFileMetadataWeb`) to retrieve file metadata and return if the following criteria are met in web mode:
- The file state is `PUBLISHED` or `MOVED`
- The file state is `UPLOADED` and the associated bundle state is `PUBLISHED`
- The file state is `UPLOADED` and the associated collection state is `PUBLISHED`

If the criteria are met, the metadata is returned with a `200` status code`, otherwise a `404` code is returned.

As part of this ticket, a new method has been added to the Files API SDK, to ensure that the Download Service  `downloads-new/{path}` endpoint behaviour is unchanged. The PR for that change is here: https://github.com/ONSdigital/dp-download-service/pull/198. Once this PR has been approved and released, the Download Service dependencies should be updated to make the SDK method available there.

### How to review

Verify that the functionality is working as expected in web mode. Check test coverage is sufficient.

### Who can review

Anyone.
