### PR TITLE
feat: SDK method updated to handle ContentItemChange in request body

### DIFF
--- a/sdk/content_item_update_put.go
+++ b/sdk/content_item_update_put.go
@@ -13,7 +13,10 @@ import (
 )
 
 func (c *Client) UpdateContentItem(ctx context.Context, filePath string, contentItem api.ContentItem, headers Headers) (*files.StoredRegisteredMetaData, error) {
-	payload, err := json.Marshal(contentItem)
+	contentItemChange := api.ContentItemChange{
+		ContentItem: &contentItem,
+	}
+	payload, err := json.Marshal(contentItemChange)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What

Amended the `UpdateContentItem` SDK method to handle a `ContentItemChange` object sent in the request body, so that a change of `series_id` can be added to the `ContentItem.PreviousSeriesId` array. This is needed so that the corresponding change in Dataset API will work (see https://github.com/ONSdigital/dp-dataset-api/pull/766).

### How to review

Verify that the `UpdateContentItem` SDK method can correctly parse a request body in the following format:

```
    "content_item": {
        "dataset_id": "<dataset-id>",
        "edition": "<edition>",
        "version": "<version>"
```

### Who can review

Anyone
